### PR TITLE
Prefer objects over multiple params in SkipRouter

### DIFF
--- a/packages/core/e2e/transactions.test.ts
+++ b/packages/core/e2e/transactions.test.ts
@@ -18,7 +18,8 @@ import {
 
 describe("transaction execution", () => {
   it("signs and executes an IBC transfer", async () => {
-    const client = new SkipRouter(SKIP_API_URL, {
+    const client = new SkipRouter({
+      apiURL: SKIP_API_URL,
       endpointOptions: {
         getRpcEndpointForChain: async () => {
           return COSMOSHUB_ENDPOINT;
@@ -46,18 +47,19 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeMultiChainMessage(
+    const tx = await client.executeMultiChainMessage({
       signerAddress,
       signer,
       message,
-      coin(1000000, "uatom"),
-    );
+      feeAmount: coin(1000000, "uatom"),
+    });
 
     expect(isDeliverTxSuccess(tx)).toBe(true);
   });
 
   it("signs and executes an IBC transfer (amino)", async () => {
-    const client = new SkipRouter(SKIP_API_URL, {
+    const client = new SkipRouter({
+      apiURL: SKIP_API_URL,
       endpointOptions: {
         getRpcEndpointForChain: async () => {
           return COSMOSHUB_ENDPOINT;
@@ -85,18 +87,19 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeMultiChainMessage(
+    const tx = await client.executeMultiChainMessage({
       signerAddress,
       signer,
       message,
-      coin(1000000, "uatom"),
-    );
+      feeAmount: coin(1000000, "uatom"),
+    });
 
     expect(isDeliverTxSuccess(tx)).toBe(true);
   });
 
   it("signs and executes an IBC transfer (injective)", async () => {
-    const client = new SkipRouter(SKIP_API_URL, {
+    const client = new SkipRouter({
+      apiURL: SKIP_API_URL,
       endpointOptions: {
         getRpcEndpointForChain: async () => {
           return INJECTIVE_RPC_ENDPOINT;
@@ -128,20 +131,21 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeMultiChainMessage(
+    const tx = await client.executeMultiChainMessage({
       signerAddress,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       signer,
       message,
-      coin(1000000, "inj"),
-    );
+      feeAmount: coin(1000000, "inj"),
+    });
 
     expect(isDeliverTxSuccess(tx)).toBe(true);
   });
 
   it("signs and executes an IBC transfer (evmos)", async () => {
-    const client = new SkipRouter(SKIP_API_URL, {
+    const client = new SkipRouter({
+      apiURL: SKIP_API_URL,
       endpointOptions: {
         getRpcEndpointForChain: async () => {
           return EVMOS_RPC_ENDPOINT;
@@ -175,14 +179,14 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeMultiChainMessage(
+    const tx = await client.executeMultiChainMessage({
       signerAddress,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       signer,
       message,
-      coin(10000000, "aevmos"),
-    );
+      feeAmount: coin(10000000, "aevmos"),
+    });
 
     expect(isDeliverTxSuccess(tx)).toBe(true);
   });
@@ -201,7 +205,8 @@ describe("transaction execution", () => {
     const faucet = new FaucetClient(OSMOSIS_FAUCET);
     await faucet.credit(signerAddress, "uosmo");
 
-    const client = new SkipRouter(SKIP_API_URL, {
+    const client = new SkipRouter({
+      apiURL: SKIP_API_URL,
       endpointOptions: {
         getRpcEndpointForChain: async () => {
           return OSMOSIS_ENDPOINT;
@@ -216,12 +221,12 @@ describe("transaction execution", () => {
       msgTypeURL: "/cosmwasm.wasm.v1.MsgExecuteContract",
     };
 
-    const tx = await client.executeMultiChainMessage(
+    const tx = await client.executeMultiChainMessage({
       signerAddress,
       signer,
       message,
-      coin(1000000, "uosmo"),
-    );
+      feeAmount: coin(1000000, "uosmo"),
+    });
 
     // CheckTx must pass but the execution will fail in DeliverTx due to invalid contract address
     expect(isDeliverTxFailure(tx)).toBe(true);
@@ -231,7 +236,8 @@ describe("transaction execution", () => {
   });
 
   it("signs and executes a cosmwasm execute message (amino)", async () => {
-    const client = new SkipRouter(SKIP_API_URL, {
+    const client = new SkipRouter({
+      apiURL: SKIP_API_URL,
       endpointOptions: {
         getRpcEndpointForChain: async () => {
           return OSMOSIS_ENDPOINT;
@@ -260,12 +266,12 @@ describe("transaction execution", () => {
       msgTypeURL: "/cosmwasm.wasm.v1.MsgExecuteContract",
     };
 
-    const tx = await client.executeMultiChainMessage(
+    const tx = await client.executeMultiChainMessage({
       signerAddress,
       signer,
       message,
-      coin(1000000, "uosmo"),
-    );
+      feeAmount: coin(1000000, "uosmo"),
+    });
 
     // CheckTx must pass but the execution will fail in DeliverTx due to invalid contract address
     expect(isDeliverTxFailure(tx)).toBe(true);

--- a/packages/core/src/__test__/client.test.ts
+++ b/packages/core/src/__test__/client.test.ts
@@ -69,10 +69,8 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       const response = await client.chains();
@@ -185,7 +183,9 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL);
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
+      });
 
       const assets = await client.assets();
 
@@ -283,7 +283,9 @@ describe("client", () => {
         ),
       );
 
-      const client = new SkipRouter(SKIP_API_URL);
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
+      });
 
       const assets = await client.assets({
         chainID: "osmosis-1",
@@ -324,10 +326,8 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       await expect(client.assets()).rejects.toThrow("Invalid chain_id");
@@ -347,10 +347,8 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       await expect(client.assets()).rejects.toThrow("internal server error");
@@ -408,10 +406,8 @@ describe("client", () => {
         ),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       const assetsFromSource = await client.assetsFromSource({
@@ -470,10 +466,8 @@ describe("client", () => {
         ),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       await expect(
@@ -501,10 +495,8 @@ describe("client", () => {
         ),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       await expect(
@@ -549,10 +541,8 @@ describe("client", () => {
         ),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       const response = await client.recommendAssets({
@@ -602,10 +592,8 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       const response = await client.messages({
@@ -723,10 +711,8 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       const response = await client.route({
@@ -806,10 +792,8 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
       const response = await client.venues();
@@ -841,16 +825,14 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
-      const response = await client.submitTransaction(
-        "cosmoshub-4",
-        "txbytes123",
-      );
+      const response = await client.submitTransaction({
+        chainID: "cosmoshub-4",
+        tx: "txbytes123",
+      });
 
       expect(response).toEqual({
         txHash: "tx_hash123",
@@ -873,16 +855,14 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
-      const response = await client.trackTransaction(
-        "cosmoshub-4",
-        "tx_hash123",
-      );
+      const response = await client.trackTransaction({
+        chainID: "cosmoshub-4",
+        txHash: "tx_hash123",
+      });
 
       expect(response).toEqual({
         txHash: "tx_hash123",
@@ -960,16 +940,14 @@ describe("client", () => {
         }),
       );
 
-      const client = new SkipRouter(SKIP_API_URL, {
-        getOfflineSigner: async () => {
-          throw new Error("not implemented");
-        },
+      const client = new SkipRouter({
+        apiURL: SKIP_API_URL,
       });
 
-      const response = await client.transactionStatus(
-        "cosmoshub-4",
-        "tx_hash123",
-      );
+      const response = await client.transactionStatus({
+        chainID: "cosmoshub-4",
+        txHash: "tx_hash123",
+      });
 
       expect(response).toEqual({
         status: "STATE_COMPLETED",

--- a/packages/examples/src/index.ts
+++ b/packages/examples/src/index.ts
@@ -16,7 +16,8 @@ const USER_ADDRESSES = {
 const MNEMONIC = ""; // <---- UPDATE THIS
 
 async function main() {
-  const client = new SkipRouter(SKIP_API_URL, {
+  const client = new SkipRouter({
+    apiURL: SKIP_API_URL,
     getOfflineSigner: async (chainID) => {
       return DirectSecp256k1HdWallet.fromMnemonic(MNEMONIC);
 
@@ -38,7 +39,9 @@ async function main() {
     cumulativeAffiliateFeeBPS: "0",
   });
 
-  await client.executeRoute(route, USER_ADDRESSES, {
+  await client.executeRoute({
+    route,
+    userAddresses: USER_ADDRESSES,
     onTransactionSuccess: async (tx) => {
       console.log(tx);
     },


### PR DESCRIPTION
Converts any public methods on `SkipRouter` to use a single options parameter instead of multiple params. Feels a bit cleaner?