### PR TITLE
Allow cw20 query param on assets req

### DIFF
--- a/packages/core/src/types/converters.ts
+++ b/packages/core/src/types/converters.ts
@@ -164,6 +164,7 @@ export function assetsRequestToJSON(
     chain_id: assetsRequest.chainID,
     native_only: assetsRequest.nativeOnly,
     include_no_metadata_assets: assetsRequest.includeNoMetadataAssets,
+    include_cw20_assets: assetsRequest.includeCw20Assets,
   };
 }
 

--- a/packages/core/src/types/types.ts
+++ b/packages/core/src/types/types.ts
@@ -66,12 +66,14 @@ export type AssetsRequestJSON = {
   chain_id?: string;
   native_only?: boolean;
   include_no_metadata_assets?: boolean;
+  include_cw20_assets?: boolean;
 };
 
 export type AssetsRequest = {
   chainID?: string;
   nativeOnly?: boolean;
   includeNoMetadataAssets?: boolean;
+  includeCw20Assets?: boolean;
 };
 
 export type Chain = {


### PR DESCRIPTION
Noticed your rest api supports a query param to conditionally show cw20 assets when querying for assets which isn't properly reflected in your ts SDK type definitions