### PR TITLE
Raise gas estimate for WasmExecuteContract calls

### DIFF
--- a/.changeset/late-items-collect.md
+++ b/.changeset/late-items-collect.md
@@ -1,0 +1,5 @@
+---
+"@skip-router/core": patch
+---
+
+Raise gas estimate for MsgExecuteContract calls

--- a/packages/core/src/transactions.ts
+++ b/packages/core/src/transactions.ts
@@ -93,7 +93,7 @@ export function getGasAmountForMessage(message: MultiChainMsg) {
     if (message.chainID === "neutron-1") {
       return "2400000";
     }
-    return "1200000";
+    return "2000000";
   }
   return "280000";
 }


### PR DESCRIPTION
We really should stop hard coding these values. We were having issues using simulation but maybe worth exploring again.