### PR TITLE
dont require chain registry to get default fee token

### DIFF
--- a/.changeset/clean-cheetahs-perform.md
+++ b/.changeset/clean-cheetahs-perform.md
@@ -1,0 +1,5 @@
+---
+"@skip-router/core": patch
+---
+
+When getting default gas token don't fail on no chain registry data

--- a/packages/core/src/__test__/client.test.ts
+++ b/packages/core/src/__test__/client.test.ts
@@ -1286,3 +1286,15 @@ describe("client", () => {
     });
   });
 });
+
+test("dymension", async () => {
+  const client = new SkipRouter({
+    apiURL: SKIP_API_URL,
+  });
+
+  const feeInfo = await client.getFeeInfoForChain("dymension_1100-1");
+
+  console.log(feeInfo);
+
+  // const result = await client
+});

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1284,13 +1284,13 @@ export class SkipRouter {
 
     const defaultGasToken = await this.getDefaultGasTokenForChain(chainID);
 
-    if (!defaultGasToken) {
+    if (!defaultGasToken && !skipChain.feeAssets) {
       return undefined;
     }
 
-    const skipFeeInfo = skipChain.feeAssets.find(
-      (skipFee) => skipFee.denom === defaultGasToken,
-    );
+    const skipFeeInfo = defaultGasToken
+      ? skipChain.feeAssets.find((skipFee) => skipFee.denom === defaultGasToken)
+      : skipChain.feeAssets[0];
 
     if (skipFeeInfo && skipFeeInfo.gasPrice !== null) {
       return skipFeeInfo;


### PR DESCRIPTION
Currently the router uses the chain registry for trying to determine the "default" gas token for a chain. Updated logic to fallback when this can't be found.