### PR TITLE
refactor: convert to getAccountNameAndSequenceFromRest

### DIFF
--- a/.changeset/witty-eels-accept.md
+++ b/.changeset/witty-eels-accept.md
@@ -1,0 +1,5 @@
+---
+"@skip-router/core": patch
+---
+
+Rename getAccountNameAndSequenceFromDymension to getAccountNameAndSequenceFromRest


### PR DESCRIPTION
Since dymension hotfix can apply for other chains, this renames `getAccountNameAndSequenceFromDymension` to `getAccountNameAndSequenceFromRest` for a more general purpose solution if chains have `base_account`s.
