### PR TITLE
Properly encode MsgExecuteContract for Injective

### DIFF
--- a/.changeset/strong-dogs-rush.md
+++ b/.changeset/strong-dogs-rush.md
@@ -1,0 +1,5 @@
+---
+"@skip-router/core": patch
+---
+
+properly encode MsgExecuteContract for Injective

--- a/package-lock.json
+++ b/package-lock.json
@@ -18543,7 +18543,7 @@
     },
     "packages/core": {
       "name": "@skip-router/core",
-      "version": "1.2.15",
+      "version": "1.3.2",
       "hasInstallScript": true,
       "dependencies": {
         "@cosmjs/amino": "0.31.x",

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -963,7 +963,7 @@ export class SkipRouter {
 
   async getAccountNumberAndSequence(address: string, chainID: string) {
     if (chainID.includes("dymension")) {
-      return this.getAccountNumberAndSequenceFromDymension(address, chainID);
+      return this.getAccountNumberAndSequenceFromDymension(address, chainID)
     }
     const endpoint = await this.getRpcEndpointForChain(chainID);
     const client = await StargateClient.connect(endpoint, {
@@ -997,8 +997,7 @@ export class SkipRouter {
     let accountNumber = 0;
     if (response.data.account.base_account) {
       sequence = response.data.account.base_account.sequence as number;
-      accountNumber = response.data.account.base_account
-        .account_number as number;
+      accountNumber = response.data.account.base_account.account_number as number;
     } else {
       sequence = response.data.account.sequence as number;
       accountNumber = response.data.account.account_number as number;

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -963,7 +963,7 @@ export class SkipRouter {
 
   async getAccountNumberAndSequence(address: string, chainID: string) {
     if (chainID.includes("dymension")) {
-      return this.getAccountNumberAndSequenceFromDymension(address, chainID)
+      return this.getAccountNumberAndSequenceFromDymension(address, chainID);
     }
     const endpoint = await this.getRpcEndpointForChain(chainID);
     const client = await StargateClient.connect(endpoint, {
@@ -997,7 +997,8 @@ export class SkipRouter {
     let accountNumber = 0;
     if (response.data.account.base_account) {
       sequence = response.data.account.base_account.sequence as number;
-      accountNumber = response.data.account.base_account.account_number as number;
+      accountNumber = response.data.account.base_account
+        .account_number as number;
     } else {
       sequence = response.data.account.sequence as number;
       accountNumber = response.data.account.account_number as number;

--- a/packages/core/src/transactions.ts
+++ b/packages/core/src/transactions.ts
@@ -91,7 +91,7 @@ export function getEncodeObjectFromMultiChainMessageInjective(
     return MsgExecuteContractInjective.fromJSON({
       sender: msgJson.sender,
       contractAddress: msgJson.contract,
-      msg: toUtf8(JSON.stringify(msgJson.msg)),
+      msg: msgJson.msg,
       funds: msgJson.funds,
     });
   }


### PR DESCRIPTION
MsgExecuteContract was not getting encoded properly for Injective and wasn't a problem previously because this branch of the code was never actually used, but now it is 😄 