### PR TITLE
added public method availability, protected properties and msgDirect endpoint call

### DIFF
--- a/.changeset/spicy-papayas-enjoy.md
+++ b/.changeset/spicy-papayas-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@skip-router/core": minor
+---
+
+Essential functions are now public for easier class extension

--- a/packages/core/e2e/transactions.test.ts
+++ b/packages/core/e2e/transactions.test.ts
@@ -35,6 +35,10 @@ describe("transaction execution", () => {
       return signer;
     }
 
+    const getGasPrice = async (chainID: string) => {
+      return GasPrice.fromString("0.25uatom");
+    }
+
     const accounts = await signer.getAccounts();
 
     const signerAddress = accounts[0].address;
@@ -54,6 +58,7 @@ describe("transaction execution", () => {
     const tx = await client.executeCosmosMessage({
       signerAddress,
       getCosmosSigner,
+      getGasPrice,
       message,
     });
 
@@ -76,6 +81,9 @@ describe("transaction execution", () => {
     const getCosmosSigner = async (chainID: string) => {
       return signer;
     }
+    const getGasPrice = async (chainID: string) => {
+      return GasPrice.fromString("0.25uatom");
+    }
 
     const accounts = await signer.getAccounts();
 
@@ -96,6 +104,7 @@ describe("transaction execution", () => {
     const tx = await client.executeCosmosMessage({
       signerAddress,
       getCosmosSigner,
+      getGasPrice,
       message,
     });
 
@@ -131,6 +140,9 @@ describe("transaction execution", () => {
     const accounts = await signer.getAccounts();
 
     const signerAddress = accounts[0].address;
+    const getGasPrice = async (chainID: string) => {
+      return GasPrice.fromString("0.25inj");
+    }
 
     const timeout = BigInt(Date.now()) * BigInt(1000000);
 
@@ -146,6 +158,7 @@ describe("transaction execution", () => {
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       getCosmosSigner,
+      getGasPrice,
       message,
 
     });
@@ -179,7 +192,11 @@ describe("transaction execution", () => {
       return signer;
     }
 
-    const accounts = await signer.getAccounts();
+    const getGasPrice = async (chainID: string) => {
+      return GasPrice.fromString("7aevmos");
+    }
+ 
+      const accounts = await signer.getAccounts();
 
     const signerAddress = accounts[0].address;
 
@@ -194,9 +211,11 @@ describe("transaction execution", () => {
 
     const tx = await client.executeCosmosMessage({
       signerAddress,
+      message,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       getCosmosSigner,
+      getGasPrice,
     });
 
     expect(isDeliverTxSuccess(tx)).toBe(true);
@@ -211,6 +230,10 @@ describe("transaction execution", () => {
     );
     const getCosmosSigner = async (chainID: string) => {
       return signer;
+    }
+
+    const getGasPrice = async (chainID: string) => {
+      return GasPrice.fromString("0.25uosmo");
     }
 
     const accounts = await signer.getAccounts();
@@ -238,6 +261,7 @@ describe("transaction execution", () => {
     const tx = await client.executeCosmosMessage({
       signerAddress,
       getCosmosSigner,
+      getGasPrice,
       message,
     });
 
@@ -268,6 +292,10 @@ describe("transaction execution", () => {
       return signer;
     }
 
+    const getGasPrice = async (chainID: string) => {
+      return GasPrice.fromString("0.25uosmo");
+    }
+
     const accounts = await signer.getAccounts();
 
     const signerAddress = accounts[0].address;
@@ -285,6 +313,7 @@ describe("transaction execution", () => {
     const tx = await client.executeCosmosMessage({
       signerAddress,
       getCosmosSigner,
+      getGasPrice,
       message,
     });
 

--- a/packages/core/e2e/transactions.test.ts
+++ b/packages/core/e2e/transactions.test.ts
@@ -47,7 +47,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeCosmosMultiChainMessage({
+    const tx = await client.executeCosmosMessage({
       signerAddress,
       signer,
       message,
@@ -90,7 +90,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeCosmosMultiChainMessage({
+    const tx = await client.executeCosmosMessage({
       signerAddress,
       signer,
       message,
@@ -137,7 +137,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeCosmosMultiChainMessage({
+    const tx = await client.executeCosmosMessage({
       signerAddress,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -188,7 +188,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeCosmosMultiChainMessage({
+    const tx = await client.executeCosmosMessage({
       signerAddress,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -233,7 +233,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/cosmwasm.wasm.v1.MsgExecuteContract",
     };
 
-    const tx = await client.executeCosmosMultiChainMessage({
+    const tx = await client.executeCosmosMessage({
       signerAddress,
       signer,
       message,
@@ -281,7 +281,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/cosmwasm.wasm.v1.MsgExecuteContract",
     };
 
-    const tx = await client.executeCosmosMultiChainMessage({
+    const tx = await client.executeCosmosMessage({
       signerAddress,
       signer,
       message,

--- a/packages/core/e2e/transactions.test.ts
+++ b/packages/core/e2e/transactions.test.ts
@@ -1,7 +1,7 @@
 import { Secp256k1HdWallet } from "@cosmjs/amino";
 import { FaucetClient } from "@cosmjs/faucet-client";
 import { coin, DirectSecp256k1HdWallet } from "@cosmjs/proto-signing";
-import { isDeliverTxFailure, isDeliverTxSuccess } from "@cosmjs/stargate";
+import { GasPrice, isDeliverTxFailure, isDeliverTxSuccess } from "@cosmjs/stargate";
 import { InjectiveDirectEthSecp256k1Wallet } from "@injectivelabs/sdk-ts";
 
 import { SKIP_API_URL, SkipRouter } from "../src";
@@ -31,6 +31,10 @@ describe("transaction execution", () => {
       "opinion knife other balcony surge more bamboo canoe romance ask argue teach anxiety adjust spike mystery wolf alone torch tail six decide wash alley",
     );
 
+    const getCosmosSigner = async (chainID: string) => {
+      return signer;
+    }
+
     const accounts = await signer.getAccounts();
 
     const signerAddress = accounts[0].address;
@@ -49,12 +53,8 @@ describe("transaction execution", () => {
 
     const tx = await client.executeCosmosMessage({
       signerAddress,
-      signer,
+      getCosmosSigner,
       message,
-      fee: {
-        amount: [coin(1000000, "uatom")],
-        gas: "200000",
-      },
     });
 
     expect(isDeliverTxSuccess(tx)).toBe(true);
@@ -73,6 +73,9 @@ describe("transaction execution", () => {
     const signer = await Secp256k1HdWallet.fromMnemonic(
       "opinion knife other balcony surge more bamboo canoe romance ask argue teach anxiety adjust spike mystery wolf alone torch tail six decide wash alley",
     );
+    const getCosmosSigner = async (chainID: string) => {
+      return signer;
+    }
 
     const accounts = await signer.getAccounts();
 
@@ -92,12 +95,8 @@ describe("transaction execution", () => {
 
     const tx = await client.executeCosmosMessage({
       signerAddress,
-      signer,
+      getCosmosSigner,
       message,
-      fee: {
-        amount: [coin(1000000, "uatom")],
-        gas: "200000",
-      },
     });
 
     expect(isDeliverTxSuccess(tx)).toBe(true);
@@ -124,6 +123,11 @@ describe("transaction execution", () => {
         ),
       ),
     );
+
+    const getCosmosSigner = async (chainID: string) => {
+      return signer;
+    }
+
     const accounts = await signer.getAccounts();
 
     const signerAddress = accounts[0].address;
@@ -141,12 +145,9 @@ describe("transaction execution", () => {
       signerAddress,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      signer,
+      getCosmosSigner,
       message,
-      fee: {
-        amount: [coin(1000000, "inj")],
-        gas: "200000",
-      },
+
     });
 
     expect(isDeliverTxSuccess(tx)).toBe(true);
@@ -174,6 +175,9 @@ describe("transaction execution", () => {
       ),
       "evmos",
     );
+    const getCosmosSigner = async (chainID: string) => {
+      return signer;
+    }
 
     const accounts = await signer.getAccounts();
 
@@ -192,12 +196,7 @@ describe("transaction execution", () => {
       signerAddress,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
-      signer,
-      message,
-      fee: {
-        amount: [coin(10000000, "aevmos")],
-        gas: "200000",
-      },
+      getCosmosSigner,
     });
 
     expect(isDeliverTxSuccess(tx)).toBe(true);
@@ -210,6 +209,9 @@ describe("transaction execution", () => {
         prefix: "osmo",
       },
     );
+    const getCosmosSigner = async (chainID: string) => {
+      return signer;
+    }
 
     const accounts = await signer.getAccounts();
     const signerAddress = accounts[0].address;
@@ -235,12 +237,8 @@ describe("transaction execution", () => {
 
     const tx = await client.executeCosmosMessage({
       signerAddress,
-      signer,
+      getCosmosSigner,
       message,
-      fee: {
-        amount: [coin(1000000, "uosmo")],
-        gas: "200000",
-      },
     });
 
     // CheckTx must pass but the execution will fail in DeliverTx due to invalid contract address
@@ -266,6 +264,9 @@ describe("transaction execution", () => {
         prefix: "osmo",
       },
     );
+    const getCosmosSigner = async (chainID: string) => {
+      return signer;
+    }
 
     const accounts = await signer.getAccounts();
 
@@ -283,12 +284,8 @@ describe("transaction execution", () => {
 
     const tx = await client.executeCosmosMessage({
       signerAddress,
-      signer,
+      getCosmosSigner,
       message,
-      fee: {
-        amount: [coin(1000000, "uosmo")],
-        gas: "200000",
-      },
     });
 
     // CheckTx must pass but the execution will fail in DeliverTx due to invalid contract address

--- a/packages/core/e2e/transactions.test.ts
+++ b/packages/core/e2e/transactions.test.ts
@@ -47,7 +47,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeMultiChainMessage({
+    const tx = await client.executeCosmosMultiChainMessage({
       signerAddress,
       signer,
       message,
@@ -90,7 +90,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeMultiChainMessage({
+    const tx = await client.executeCosmosMultiChainMessage({
       signerAddress,
       signer,
       message,
@@ -137,7 +137,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeMultiChainMessage({
+    const tx = await client.executeCosmosMultiChainMessage({
       signerAddress,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -188,7 +188,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/ibc.applications.transfer.v1.MsgTransfer",
     };
 
-    const tx = await client.executeMultiChainMessage({
+    const tx = await client.executeCosmosMultiChainMessage({
       signerAddress,
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
@@ -233,7 +233,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/cosmwasm.wasm.v1.MsgExecuteContract",
     };
 
-    const tx = await client.executeMultiChainMessage({
+    const tx = await client.executeCosmosMultiChainMessage({
       signerAddress,
       signer,
       message,
@@ -281,7 +281,7 @@ describe("transaction execution", () => {
       msgTypeURL: "/cosmwasm.wasm.v1.MsgExecuteContract",
     };
 
-    const tx = await client.executeMultiChainMessage({
+    const tx = await client.executeCosmosMultiChainMessage({
       signerAddress,
       signer,
       message,

--- a/packages/core/src/client-types.ts
+++ b/packages/core/src/client-types.ts
@@ -60,7 +60,15 @@ export type ExecuteRouteOptions = {
   gasAmountMultiplier?: number;
 };
 
+
 export type ExecuteMultiChainMessageOptions = {
+  signerAddress: string;
+  signer: OfflineSigner;
+  message: types.MultiChainMsg;
+  fee: StdFee;
+};
+
+export type ExecuteCosmosMessage = {
   signerAddress: string;
   getCosmosSigner: (chainID: string) => Promise<OfflineSigner>;
   getGasPrice?: (chainID: string) => Promise<GasPrice | undefined>;

--- a/packages/core/src/client-types.ts
+++ b/packages/core/src/client-types.ts
@@ -62,9 +62,10 @@ export type ExecuteRouteOptions = {
 
 export type ExecuteMultiChainMessageOptions = {
   signerAddress: string;
-  signer: OfflineSigner;
+  getCosmosSigner: (chainID: string) => Promise<OfflineSigner>;
+  getGasPrice?: (chainID: string) => Promise<GasPrice | undefined>;
   message: types.MultiChainMsg;
-  fee: StdFee;
+  gasAmountMultiplier?: number;
 };
 
 export type SignMultiChainMessageDirectOptions = {

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1,10 +1,11 @@
-import { makeSignDoc as makeSignDocAmino } from "@cosmjs/amino";
+import { coin, makeSignDoc as makeSignDocAmino } from "@cosmjs/amino";
 import { createWasmAminoConverters } from "@cosmjs/cosmwasm-stargate";
 import { fromBase64 } from "@cosmjs/encoding";
 import { Int53 } from "@cosmjs/math";
 import { Decimal } from "@cosmjs/math";
 import { makePubkeyAnyFromAccount } from "./proto-signing/pubkey";
 import {
+  EncodeObject,
   isOfflineDirectSigner,
   makeAuthInfoBytes,
   makeSignDoc,
@@ -58,25 +59,26 @@ import {
 } from "./transactions";
 import * as types from "./types";
 import * as clientTypes from "./client-types";
+import { msgsDirectRequestToJSON } from "./types/converters";
 
 export const SKIP_API_URL = "https://api.skip.money";
 
 export class SkipRouter {
   private requestClient: RequestClient;
 
-  private aminoTypes: AminoTypes;
-  private registry: Registry;
+  protected aminoTypes: AminoTypes;
+  protected registry: Registry;
 
-  private clientID: string;
+  protected clientID: string;
 
-  private endpointOptions: {
+  protected endpointOptions: {
     endpoints?: Record<string, clientTypes.EndpointOptions>;
     getRpcEndpointForChain?: (chainID: string) => Promise<string>;
     getRestEndpointForChain?: (chainID: string) => Promise<string>;
   };
 
-  private getCosmosSigner?: (chainID: string) => Promise<OfflineSigner>;
-  private getEVMSigner?: (chainID: string) => Promise<WalletClient>;
+  protected getCosmosSigner?: (chainID: string) => Promise<OfflineSigner>;
+  protected getEVMSigner?: (chainID: string) => Promise<WalletClient>;
 
   constructor(options: clientTypes.SkipRouterOptions = {}) {
     this.clientID = options.clientID || "skip-router-js";
@@ -196,17 +198,7 @@ export class SkipRouter {
     const {
       route,
       userAddresses,
-      validateGasBalance,
-      getGasPrice,
-      gasAmountMultiplier = DEFAULT_GAS_MULTIPLIER,
     } = options;
-
-    const getOfflineSigner = this.getCosmosSigner || options.getCosmosSigner;
-    if (!getOfflineSigner) {
-      throw new Error(
-        "executeRoute error: 'getCosmosSigner' is not provided or configured in skip router",
-      );
-    }
 
     const addressList = route.chainIDs.map((chainID) => {
       return (
@@ -227,6 +219,26 @@ export class SkipRouter {
       slippageTolerancePercent: options.slippageTolerancePercent || "1",
     });
 
+    this.executeMultiChainMsgs({ ...options, messages });
+  }
+
+  async executeMultiChainMsgs(options: clientTypes.ExecuteRouteOptions & { messages: types.Msg[] }) {
+    const {
+      messages,
+      route,
+      userAddresses,
+      validateGasBalance,
+      getGasPrice,
+      gasAmountMultiplier = DEFAULT_GAS_MULTIPLIER,
+    } = options;
+
+    const getOfflineSigner = this.getCosmosSigner || options.getCosmosSigner;
+    if (!getOfflineSigner) {
+      throw new Error(
+        "executeRoute error: 'getCosmosSigner' is not provided or configured in skip router",
+      );
+    }
+
     if (validateGasBalance) {
       // check balances on chains where a tx is initiated
       await this.validateGasBalances(
@@ -238,133 +250,85 @@ export class SkipRouter {
       );
     }
 
-    // execute txs
     for (let i = 0; i < messages.length; i++) {
-      const message = messages[i]!;
-
-      if ("multiChainMsg" in message) {
-        const { multiChainMsg } = message;
-
-        const signer = await getOfflineSigner(multiChainMsg.chainID);
-
-        const gasPrice =
-          (getGasPrice
-            ? await getGasPrice(multiChainMsg.chainID)
-            : await this.getRecommendedGasPrice(multiChainMsg.chainID)) ||
-          raise(
-            `executeRoute error: unable to get gas prices for chain '${multiChainMsg.chainID}'`,
-          );
-
-        const endpoint = await this.getRpcEndpointForChain(
-          multiChainMsg.chainID,
-        );
-
-        const client = await SigningStargateClient.connectWithSigner(
-          endpoint,
-          signer,
-          {
-            aminoTypes: this.aminoTypes,
-            registry: this.registry,
-            accountParser,
-          },
-        );
-
-        const currentUserAddress = userAddresses[multiChainMsg.chainID];
-        if (!currentUserAddress) {
-          throw new Error(
-            `executeRoute error: invalid address for chain '${multiChainMsg.chainID}'`,
-          );
-        }
-
-        const estimatedGas = await getGasAmountForMessage(
-          client,
-          currentUserAddress,
-          multiChainMsg,
-          gasAmountMultiplier,
-        );
-
-        const fee = calculateFee(Math.ceil(parseFloat(estimatedGas)), gasPrice);
-
-        if (!fee) {
-          throw new Error(
-            `executeRoute error: unable to get fee for message #${i}`,
-          );
-        }
-
-        const tx = await this.executeMultiChainMessage({
-          signerAddress: currentUserAddress,
-          signer,
-          message: multiChainMsg,
-          fee,
-        });
-
-        if (options.onTransactionBroadcast) {
-          await options.onTransactionBroadcast({
-            chainID: multiChainMsg.chainID,
-            txHash: tx.transactionHash,
-          });
-        }
-
-        const txStatusResponse = await this.waitForTransaction({
-          chainID: multiChainMsg.chainID,
-          txHash: tx.transactionHash,
-          onTransactionTracked: options.onTransactionTracked,
-        });
-
-        if (options.onTransactionCompleted) {
-          await options.onTransactionCompleted(
-            multiChainMsg.chainID,
-            tx.transactionHash,
-            txStatusResponse,
-          );
-        }
+      const message = messages[i];
+      if (!message) {
+        raise(`executeRoute error: invalid message at index ${i}`);
       }
 
-      if ("evmTx" in message) {
-        const { evmTx } = message;
+      let txResult: { chainID: string, txHash: string };
+      if ("multiChainMsg" in message) { // TODO: use typeguard instead
+        const multiChainMessage = message.multiChainMsg
 
-        const getEVMSigner = options.getEVMSigner || this.getEVMSigner;
-        if (!getEVMSigner) {
-          throw new Error(
-            "executeRoute error: 'getEVMSigner' is not provided or configured in skip router",
-          );
+        const currentUserAddress = userAddresses[multiChainMessage.chainID];
+        if (!currentUserAddress) {
+          raise(`executeRoute error: invalid address for chain '${multiChainMessage.chainID}'`);
         }
-
-        const evmSigner = await getEVMSigner(evmTx.chainID);
-
-        const txReceipt = await this.executeEVMTransaction({
-          message: evmTx,
-          signer: evmSigner,
+        const txResponse = await this.executeCosmosMultiChainMessage({
+          message: multiChainMessage,
+          getCosmosSigner: getOfflineSigner,
+          getGasPrice: getGasPrice,
+          gasAmountMultiplier,
+          signerAddress: currentUserAddress
         });
 
-        if (options.onTransactionBroadcast) {
-          await options.onTransactionBroadcast({
-            chainID: evmTx.chainID,
-            txHash: txReceipt.transactionHash,
-          });
-        }
 
-        const txStatusResponse = await this.waitForTransaction({
-          chainID: evmTx.chainID,
-          txHash: txReceipt.transactionHash,
-          onTransactionTracked: options.onTransactionTracked,
-        });
-
-        if (options.onTransactionCompleted) {
-          await options.onTransactionCompleted(
-            evmTx.chainID,
-            txReceipt.transactionHash,
-            txStatusResponse,
-          );
+        txResult = {
+          chainID: multiChainMessage.chainID,
+          txHash: txResponse.transactionHash
         }
+      } else if ("evmTx" in message) {
+        const txResponse = await this.executeEvmMultiChainMsg(message, options);
+        txResult = {
+          chainID: message.evmTx.chainID,
+          txHash: txResponse.transactionHash,
+        }
+      } else {
+        raise(`executeRoute error: invalid message type`);
+      }
+
+      if (options.onTransactionBroadcast) {
+        await options.onTransactionBroadcast({ ...txResult });
+      }
+
+      const txStatusResponse = await this.waitForTransaction({
+        ...txResult,
+        onTransactionTracked: options.onTransactionTracked,
+      });
+
+      if (options.onTransactionCompleted) {
+        await options.onTransactionCompleted(
+          txResult.chainID,
+          txResult.txHash,
+          txStatusResponse,
+        );
       }
     }
   }
 
-  async executeMultiChainMessage(
+  private async executeEvmMultiChainMsg(message: { evmTx: types.EvmTx; }, options: clientTypes.ExecuteRouteOptions) {
+    const { evmTx } = message;
+
+    let getEVMSigner = options.getEVMSigner || this.getEVMSigner;
+    if (!getEVMSigner) {
+      throw new Error("Unable to get EVM signer");
+    }
+
+    const evmSigner = await getEVMSigner(evmTx.chainID);
+
+    return await this.executeEVMTransaction({
+      message: evmTx,
+      signer: evmSigner,
+    });
+  }
+
+  async executeCosmosMultiChainMessage(
     options: clientTypes.ExecuteMultiChainMessageOptions,
   ) {
-    const { signerAddress, signer, message, fee } = options;
+    const { signerAddress, getCosmosSigner, message, getGasPrice, gasAmountMultiplier } = options;
+
+    const signer = await getCosmosSigner(message.chainID);
+
 
     const accounts = await signer.getAccounts();
     const accountFromSigner = accounts.find(
@@ -377,6 +341,8 @@ export class SkipRouter {
       );
     }
 
+
+
     const endpoint = await this.getRpcEndpointForChain(message.chainID);
 
     const stargateClient = await SigningStargateClient.connectWithSigner(
@@ -388,6 +354,12 @@ export class SkipRouter {
         accountParser,
       },
     );
+
+    // @note: reusing the stargate client here and for broadcast 👍
+    const fee = await this.estimateGasForMessage(
+      stargateClient,
+      signerAddress, message.chainID, gasAmountMultiplier, getGasPrice, message);
+
     const { accountNumber, sequence } = await this.getAccountNumberAndSequence(
       signerAddress,
       message.chainID,
@@ -425,6 +397,40 @@ export class SkipRouter {
     const tx = await stargateClient.broadcastTx(txBytes);
 
     return tx;
+  }
+
+  async estimateGasForMessage(
+    stargateClient: SigningStargateClient,
+    chainID: string,
+    signerAddress: string,
+    gasAmountMultiplier: number | undefined,
+    getGasPrice?: (chainID: string) => Promise<GasPrice | undefined>,
+    message?: types.MultiChainMsg,
+    encodedMsgs?: EncodeObject[]
+  ) {
+    const estimatedGas = await getGasAmountForMessage(
+      stargateClient,
+      signerAddress,
+      message,
+      encodedMsgs,
+      gasAmountMultiplier
+    );
+
+    const gasPrice =
+    (getGasPrice
+      ? await getGasPrice(chainID)
+      : await this.getRecommendedGasPrice(chainID)) ||
+      raise(
+        `executeRoute error: unable to get gas prices for chain '${chainID}'`
+      );
+
+
+    const fee = calculateFee(Math.ceil(parseFloat(estimatedGas)), gasPrice);
+
+    if (!fee) {
+        raise(`executeRoute error: unable to get fee for message(s) ${message || encodedMsgs}`);
+    }
+    return fee;
   }
 
   async executeEVMTransaction({
@@ -815,6 +821,20 @@ export class SkipRouter {
     return types.routeResponseFromJSON(response);
   }
 
+  async msgsDirect(options: types.MsgsDirectRequest): Promise<types.MsgsDirectResponse> {
+    const response = await this.requestClient.post<
+      types.MsgsDirectResponseJSON,
+      types.MsgsDirectRequestJSON
+    >("/v2/fungible/msgs_direct", {
+      ...msgsDirectRequestToJSON(options),
+    });
+
+    return {
+      msgs: response.msgs.map((msg) => types.msgFromJSON(msg)),
+      route: types.routeResponseFromJSON(response.route),
+    };
+  }
+
   async recommendAssets(
     request:
       | types.AssetRecommendationRequest
@@ -1098,7 +1118,7 @@ export class SkipRouter {
     };
   }
 
-  private async getRpcEndpointForChain(chainID: string) {
+  async getRpcEndpointForChain(chainID: string) {
     if (this.endpointOptions.getRpcEndpointForChain) {
       return this.endpointOptions.getRpcEndpointForChain(chainID);
     }
@@ -1133,7 +1153,7 @@ export class SkipRouter {
     return endpoint;
   }
 
-  private async getRestEndpointForChain(chainID: string) {
+  async getRestEndpointForChain(chainID: string) {
     if (this.endpointOptions.getRestEndpointForChain) {
       return this.endpointOptions.getRestEndpointForChain(chainID);
     }
@@ -1210,6 +1230,7 @@ export class SkipRouter {
       client,
       signerAddress,
       msg,
+      undefined,
       gasAmountMultiplier,
     );
 
@@ -1368,6 +1389,7 @@ export class SkipRouter {
         const endpoint = await this.getRpcEndpointForChain(
           message.multiChainMsg.chainID,
         );
+        // @note: A new client is created for both the gasbalance validation here as the execution later...
         const client = await SigningStargateClient.connectWithSigner(
           endpoint,
           signer,
@@ -1426,10 +1448,8 @@ export class SkipRouter {
 
     if (parseInt(balance.amount) < parseInt(fee.amount[0].amount)) {
       throw new Error(
-        `Insufficient fee token to initiate transfer on ${
-          message.chainID
-        }. Need ${parseInt(fee.amount[0].amount)} ${
-          fee.amount[0].denom
+        `Insufficient fee token to initiate transfer on ${message.chainID
+        }. Need ${parseInt(fee.amount[0].amount)} ${fee.amount[0].denom
         }, but only have ${balance.amount} ${fee.amount[0].denom}.`,
       );
     }
@@ -1443,3 +1463,4 @@ function raise(message?: string, options?: ErrorOptions): never {
 function wait(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,4 +2,3 @@ export * from "./client";
 export * from "./client-types";
 export * from "./types";
 export * from "./transactions";
-export { circleAminoConverters, circleProtoRegistry } from "./codegen/circle/client"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./client";
 export * from "./client-types";
 export * from "./types";
+export * from "./transactions";
+export { circleAminoConverters, circleProtoRegistry } from "./codegen/circle/client"

--- a/packages/core/src/transactions.ts
+++ b/packages/core/src/transactions.ts
@@ -102,24 +102,31 @@ export function getEncodeObjectFromMultiChainMessageInjective(
 export async function getGasAmountForMessage(
   client: SigningStargateClient,
   signerAddress: string,
-  message: MultiChainMsg,
+  message?: MultiChainMsg,
+  encodedMsgs?: EncodeObject[],
   multiplier: number = DEFAULT_GAS_MULTIPLIER,
 ) {
+
+  
+  if (!message && !encodedMsgs) {
+    throw new Error("Either message or encodedMsg must be provided");
+  }
+  
+  encodedMsgs = encodedMsgs || [getEncodeObjectFromMultiChainMessage(message!)];
   if (
-    message.chainID.includes("evmos") ||
-    message.chainID.includes("injective") ||
-    message.chainID.includes("dymension") ||
-    process.env.NODE_ENV === "test"
+    message?.chainID.includes("evmos") ||
+    message?.chainID.includes("injective") ||
+    message?.chainID.includes("dymension") ||
+    process?.env.NODE_ENV === "test"
   ) {
-    if (message.msgTypeURL === "/cosmwasm.wasm.v1.MsgExecuteContract") {
+    if (message?.msgTypeURL === "/cosmwasm.wasm.v1.MsgExecuteContract") {
       return "2400000";
     }
     return "280000";
   }
 
-  const encodeMsg = getEncodeObjectFromMultiChainMessage(message);
 
-  const estimatedGas = await client.simulate(signerAddress, [encodeMsg], "");
+  const estimatedGas = await client.simulate(signerAddress, encodedMsgs, "");
 
   const estimatedGasWithBuffer = estimatedGas * multiplier;
 

--- a/packages/core/src/types/converters.ts
+++ b/packages/core/src/types/converters.ts
@@ -114,6 +114,8 @@ import {
   BridgesResponseJSON,
   Msg,
   MsgJSON,
+  MsgsDirectRequest,
+  MsgsDirectRequestJSON,
   MsgsRequest,
   MsgsRequestJSON,
   Operation,
@@ -1811,5 +1813,58 @@ export function hyperlaneTransferInfoToJSON(
     to_chain_id: value.toChainID,
     state: value.state,
     txs: value.txs && hyperlaneTransferTransactionsToJSON(value.txs),
+  };
+
+}
+
+export function msgsDirectRequestFromJSON(
+  msgDirectRequestJSON: MsgsDirectRequestJSON,
+): MsgsDirectRequest {
+  return {
+    sourceAssetDenom: msgDirectRequestJSON.source_asset_denom,
+    sourceAssetChainID: msgDirectRequestJSON.source_asset_chain_id,
+    destAssetDenom: msgDirectRequestJSON.dest_asset_denom,
+    destAssetChainID: msgDirectRequestJSON.dest_asset_chain_id,
+    amountIn: msgDirectRequestJSON.amount_in,
+    amountOut: msgDirectRequestJSON.amount_out,
+    chainIdsToAddresses: msgDirectRequestJSON.chain_ids_to_addresses,
+    slippageTolerancePercent: msgDirectRequestJSON.slippage_tolerance_percent,
+    affiliates: msgDirectRequestJSON.affiliates?.map(affiliateFromJSON),
+    timeoutSeconds: msgDirectRequestJSON.timeout_seconds,
+    postRouteHandler:
+      msgDirectRequestJSON.post_route_handler &&
+      postHandlerFromJSON(msgDirectRequestJSON.post_route_handler),
+    swapVenue: 
+        msgDirectRequestJSON.swap_venue && 
+        swapVenueFromJSON(msgDirectRequestJSON.swap_venue),
+
+  };
+}
+
+export function msgsDirectRequestToJSON(
+  msgDirectRequest: MsgsDirectRequest,
+): MsgsDirectRequestJSON {
+  return {
+    source_asset_denom: msgDirectRequest.sourceAssetDenom,
+    source_asset_chain_id: msgDirectRequest.sourceAssetChainID,
+    dest_asset_denom: msgDirectRequest.destAssetDenom,
+    dest_asset_chain_id: msgDirectRequest.destAssetChainID,
+    amount_in: msgDirectRequest.amountIn,
+    amount_out: msgDirectRequest.amountOut,
+    chain_ids_to_addresses: msgDirectRequest.chainIdsToAddresses,
+    slippage_tolerance_percent: msgDirectRequest.slippageTolerancePercent,
+    affiliates: msgDirectRequest.affiliates?.map(affiliateToJSON),
+    allow_multi_tx: msgDirectRequest.allowMultiTx,
+    allow_unsafe: msgDirectRequest.allowUnsafe,
+    bridges: msgDirectRequest.bridges,
+    timeout_seconds: msgDirectRequest.timeoutSeconds,
+    client_id: msgDirectRequest.clientID,
+    experimental_features: msgDirectRequest.experimentalFeatures,
+    swap_venue: 
+      msgDirectRequest.swapVenue &&
+      swapVenueToJSON(msgDirectRequest.swapVenue),
+    post_route_handler:
+      msgDirectRequest.postRouteHandler &&
+      postHandlerToJSON(msgDirectRequest.postRouteHandler),
   };
 }

--- a/packages/core/src/types/unified.ts
+++ b/packages/core/src/types/unified.ts
@@ -146,6 +146,16 @@ export type RouteRequestJSON =
   | RouteRequestGivenInJSON
   | RouteRequestGivenOutJSON;
 
+export type MsgsDirectResponse = {
+  msgs: Msg[]
+  route: RouteResponse
+}
+
+export type MsgsDirectResponseJSON = {
+  msgs: MsgJSON[]
+  route: RouteResponseJSON
+}
+
 export type RouteRequestBase = {
   sourceAssetDenom: string;
   sourceAssetChainID: string;
@@ -282,6 +292,55 @@ export type MsgsRequest = {
   postRouteHandler?: PostHandler;
 
   clientID?: string;
+};
+
+export type MsgsDirectRequestJSON = {
+  source_asset_denom: string
+  source_asset_chain_id: string
+  dest_asset_denom: string
+  dest_asset_chain_id: string
+  amount_in: string
+  amount_out: string
+  chain_ids_to_addresses: {
+    [key: string]: string
+  }
+  swap_venue?: SwapVenueJSON
+  slippage_tolerance_percent?: string
+  timeout_seconds?: string
+
+  affiliates?: AffiliateJSON[]
+
+  post_route_handler?: PostHandlerJSON
+
+  allow_unsafe?: boolean;
+  client_id?: string;
+  experimental_features?: ExperimentalFeature[];
+  bridges?: BridgeType[];
+  allow_multi_tx?: boolean;
+}
+
+export type MsgsDirectRequest = {
+  sourceAssetDenom: string;
+  sourceAssetChainID: string;
+  destAssetDenom: string;
+  destAssetChainID: string;
+  amountIn: string;
+  amountOut: string;
+  chainIdsToAddresses: {
+    [key: string]: string
+  };
+  swapVenue?: SwapVenue;
+  slippageTolerancePercent?: string;
+  timeoutSeconds?: string;
+  affiliates?: Affiliate[];
+
+  postRouteHandler?: PostHandler;
+  
+  allowUnsafe?: boolean;
+  clientID?: string;
+  experimentalFeatures?: ExperimentalFeature[];
+  bridges?: BridgeType[];
+  allowMultiTx?: boolean;
 };
 
 export type MsgJSON =


### PR DESCRIPTION
This pull requests changes the following:

- removes the private statement for some of the methods to expose them on the skipRouter object
- changes private properties to protected, so the SkipRouter Class can be extended 
- pulls large code from `executeRoute` into `executeMultiChainMsgs`
- renames `executeMultiChainMessage` to `executeCosmosMultiChainMessage` to prevent confusion
- adds `estimateGasForMessage` function to expose this to the skipRouter object and improve readability
- expose functions of `transactions.ts` to enable importing of those methods
- expose circle cctp codegen types for convenient import

**note:** I dont know why the package-lock.json bumped the version, because i didnt change manually. If this is undesired, please let me know and ill revert that.

