### PR TITLE
Define and use correct Hyperlane types for lifecycle tracking

### DIFF
--- a/.changeset/short-vans-relax.md
+++ b/.changeset/short-vans-relax.md
@@ -1,0 +1,5 @@
+---
+"@skip-router/core": patch
+---
+
+Define and use correct hyperlane types for lifecycle tracking

--- a/packages/core/src/types/converters.ts
+++ b/packages/core/src/types/converters.ts
@@ -11,6 +11,10 @@ import {
   ChainTransactionJSON,
   ContractCallWithTokenTransactions,
   ContractCallWithTokenTransactionsJSON,
+  HyperlaneTransferInfo,
+  HyperlaneTransferInfoJSON,
+  HyperlaneTransferTransactions,
+  HyperlaneTransferTransactionsJSON,
   NextBlockingTransfer,
   NextBlockingTransferJSON,
   Packet,
@@ -1431,7 +1435,9 @@ export function transferEventFromJSON(value: TransferEventJSON): TransferEvent {
 
   if ("hyperlane_transfer" in value) {
     return {
-      hyperlaneTransfer: hyperlaneTransferFromJSON(value.hyperlane_transfer),
+      hyperlaneTransfer: hyperlaneTransferInfoFromJSON(
+        value.hyperlane_transfer,
+      ),
     };
   }
 
@@ -1455,7 +1461,7 @@ export function transferEventToJSON(value: TransferEvent): TransferEventJSON {
 
   if ("hyperlaneTransfer" in value) {
     return {
-      hyperlane_transfer: hyperlaneTransferToJSON(value.hyperlaneTransfer),
+      hyperlane_transfer: hyperlaneTransferInfoToJSON(value.hyperlaneTransfer),
     };
   }
 
@@ -1731,5 +1737,49 @@ export function cctpTransferInfoToJSON(
     dst_chain_id: value.dstChainID,
     state: value.state,
     txs: value.txs && cctpTransferTransactionsToJSON(value.txs),
+  };
+}
+
+export function hyperlaneTransferTransactionsFromJSON(
+  value: HyperlaneTransferTransactionsJSON,
+): HyperlaneTransferTransactions {
+  return {
+    sendTx: value.send_tx ? chainTransactionFromJSON(value.send_tx) : null,
+    receiveTx: value.receive_tx
+      ? chainTransactionFromJSON(value.receive_tx)
+      : null,
+  };
+}
+
+export function hyperlaneTransferTransactionsToJSON(
+  value: HyperlaneTransferTransactions,
+): HyperlaneTransferTransactionsJSON {
+  return {
+    send_tx: value.sendTx ? chainTransactionToJSON(value.sendTx) : null,
+    receive_tx: value.receiveTx
+      ? chainTransactionToJSON(value.receiveTx)
+      : null,
+  };
+}
+
+export function hyperlaneTransferInfoFromJSON(
+  value: HyperlaneTransferInfoJSON,
+): HyperlaneTransferInfo {
+  return {
+    fromChainID: value.from_chain_id,
+    toChainID: value.to_chain_id,
+    state: value.state,
+    txs: value.txs && hyperlaneTransferTransactionsFromJSON(value.txs),
+  };
+}
+
+export function hyperlaneTransferInfoToJSON(
+  value: HyperlaneTransferInfo,
+): HyperlaneTransferInfoJSON {
+  return {
+    from_chain_id: value.fromChainID,
+    to_chain_id: value.toChainID,
+    state: value.state,
+    txs: value.txs && hyperlaneTransferTransactionsToJSON(value.txs),
   };
 }

--- a/packages/core/src/types/lifecycle.ts
+++ b/packages/core/src/types/lifecycle.ts
@@ -1,5 +1,3 @@
-import { HyperlaneTransfer, HyperlaneTransferJSON } from "./shared";
-
 export type SubmitTxRequestJSON = {
   tx: string;
   chain_id: string;
@@ -348,6 +346,36 @@ export type CCTPTransferInfo = {
   txs: CCTPTransferTransactions;
 };
 
+export type HyperlaneTransferState =
+  | "HYPERLANE_TRANSFER_UNKNOWN"
+  | "HYPERLANE_TRANSFER_SENT"
+  | "HYPERLANE_TRANSFER_FAILED"
+  | "HYPERLANE_TRANSFER_RECEIVED";
+
+export type HyperlaneTransferTransactionsJSON = {
+  send_tx: ChainTransactionJSON | null;
+  receive_tx: ChainTransactionJSON | null;
+};
+
+export type HyperlaneTransferTransactions = {
+  sendTx: ChainTransaction | null;
+  receiveTx: ChainTransaction | null;
+};
+
+export type HyperlaneTransferInfoJSON = {
+  from_chain_id: string;
+  to_chain_id: string;
+  state: HyperlaneTransferState;
+  txs: HyperlaneTransferTransactionsJSON;
+};
+
+export type HyperlaneTransferInfo = {
+  fromChainID: string;
+  toChainID: string;
+  state: HyperlaneTransferState;
+  txs: HyperlaneTransferTransactions;
+};
+
 export type TransferEventJSON =
   | {
       ibc_transfer: TransferInfoJSON;
@@ -356,7 +384,7 @@ export type TransferEventJSON =
       axelar_transfer: AxelarTransferInfoJSON;
     }
   | { cctp_transfer: CCTPTransferInfoJSON }
-  | { hyperlane_transfer: HyperlaneTransferJSON };
+  | { hyperlane_transfer: HyperlaneTransferInfoJSON };
 
 export type TransferEvent =
   | {
@@ -364,4 +392,4 @@ export type TransferEvent =
     }
   | { axelarTransfer: AxelarTransferInfo }
   | { cctpTransfer: CCTPTransferInfo }
-  | { hyperlaneTransfer: HyperlaneTransfer };
+  | { hyperlaneTransfer: HyperlaneTransferInfo };


### PR DESCRIPTION
#124 uses the wrong types in lifecycle tracking, this corrects it.