### PR TITLE
Revert "add transfer-state field to next_blocking_transfer schema"

### DIFF
--- a/packages/core/src/types/converters.ts
+++ b/packages/core/src/types/converters.ts
@@ -1030,7 +1030,6 @@ export function nextBlockingTransferFromJSON(
 ): NextBlockingTransfer {
   return {
     transferSequenceIndex: nextBlockingTransferJSON.transfer_sequence_index,
-    transferState: nextBlockingTransferJSON.transfer_state,
   };
 }
 
@@ -1039,7 +1038,6 @@ export function nextBlockingTransferToJSON(
 ): NextBlockingTransferJSON {
   return {
     transfer_sequence_index: nextBlockingTransfer.transferSequenceIndex,
-    transfer_state: nextBlockingTransfer.transferState,
   };
 }
 

--- a/packages/core/src/types/lifecycle.ts
+++ b/packages/core/src/types/lifecycle.ts
@@ -30,18 +30,12 @@ export type StatusState =
   | "STATE_COMPLETED_SUCCESS"
   | "STATE_COMPLETED_ERROR";
 
-export type BlockingTransferState = 
-  | "TRANSFER_PROPAGATING"
-  | "ERROR_PROPAGATING"
-
 export type NextBlockingTransferJSON = {
   transfer_sequence_index: number;
-  transfer_state: BlockingTransferState;
 };
 
 export type NextBlockingTransfer = {
   transferSequenceIndex: number;
-  transferState: BlockingTransferState;
 };
 
 export type StatusRequestJSON = {


### PR DESCRIPTION
Reverts skip-mev/skip-router-sdk#111 since we removed the `transfer_state` field