### PR TITLE
bump chain registry dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1931,9 +1931,9 @@
       "dev": true
     },
     "node_modules/@chain-registry/types": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@chain-registry/types/-/types-0.18.0.tgz",
-      "integrity": "sha512-jRFOKOMIAcA5Qp5cXEiAPyXs13WbSP19kvcb8qm5vaRwXvHMufPd/ZxLC80yq/LB62FeZeaVYfsjorLf3M6tTw==",
+      "version": "0.18.7",
+      "resolved": "https://registry.npmjs.org/@chain-registry/types/-/types-0.18.7.tgz",
+      "integrity": "sha512-HWvLosHHnu1bNVeIfvdaDbXPcKlMGzebIyWrFC7AZ/ijmNToFJj4mQ/Bou0ahN/ITXKRGCjMpuoxY7fyTDu3Wg==",
       "dependencies": {
         "@babel/runtime": "^7.21.0"
       }
@@ -7761,12 +7761,12 @@
       }
     },
     "node_modules/chain-registry": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/chain-registry/-/chain-registry-1.28.0.tgz",
-      "integrity": "sha512-pKaTIadZ3ZkHZFiV0Uzl80Ohx6pa/AdzXjo5t2VMYK802AFptXcEe9VEs9ZMNR8Fd5vDEDW1p3n3C3Pp5gGKxQ==",
+      "version": "1.33.11",
+      "resolved": "https://registry.npmjs.org/chain-registry/-/chain-registry-1.33.11.tgz",
+      "integrity": "sha512-M0k7CNYtZXtJbxhbyviUv/k37z/+6G825oicNWTZhtJxYwSGymC3CzY9zWobnKH/Vgn3MbcZ/PKznE5W3I/Cqg==",
       "dependencies": {
         "@babel/runtime": "^7.21.0",
-        "@chain-registry/types": "^0.18.0"
+        "@chain-registry/types": "^0.18.7"
       }
     },
     "node_modules/chalk": {
@@ -18948,7 +18948,7 @@
     },
     "packages/core": {
       "name": "@skip-router/core",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "hasInstallScript": true,
       "dependencies": {
         "@cosmjs/amino": "0.31.x",
@@ -18980,7 +18980,7 @@
         "vitest": "^1.2.2"
       },
       "peerDependencies": {
-        "chain-registry": "^1.28.0"
+        "chain-registry": "^1.33.11"
       }
     },
     "packages/core/node_modules/@injectivelabs/core-proto-ts": {
@@ -19886,9 +19886,9 @@
       }
     },
     "packages/examples": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "dependencies": {
-        "@skip-router/core": "2.0.0"
+        "@skip-router/core": "2.0.1"
       }
     },
     "vendor": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,7 +27,7 @@
     "watch": "tsup --watch"
   },
   "peerDependencies": {
-    "chain-registry": "^1.28.0"
+    "chain-registry": "^1.33.11"
   },
   "dependencies": {
     "@cosmjs/amino": "0.31.x",


### PR DESCRIPTION
Bumping the chain registry dependency so it gets the new ordering in the dYdX RPC list updated [here](https://github.com/cosmos/chain-registry/pull/4219).