### PR TITLE
Rename Rapid Relay to Smart Relay

### DIFF
--- a/.changeset/short-glasses-vanish.md
+++ b/.changeset/short-glasses-vanish.md
@@ -1,0 +1,5 @@
+---
+"@skip-router/core": minor
+---
+
+Rename rapid_relay to smart_relay

--- a/packages/core/e2e/transactions.test.ts
+++ b/packages/core/e2e/transactions.test.ts
@@ -389,7 +389,7 @@ describe("transaction execution", () => {
                 destDenom:
                   "ibc/14F9BC3E44B8A9C1BE1FB08980FAB87034C9905EF17CF2F5008FC085218811CC",
                 chainID: "osmosis-1",
-                rapidRelay: true,
+                smartRelay: true,
               },
             },
           ],

--- a/packages/core/src/__test__/client.test.ts
+++ b/packages/core/src/__test__/client.test.ts
@@ -684,7 +684,7 @@ describe("client", () => {
               denomIn:
                 "ibc/27394FB092D2ECCD56123C74F36E4C1F926001CEADA9CA97EA622B25F41E5EB2",
               denomOut: "uatom",
-              rapidRelay: true,
+              smartRelay: true,
             },
           },
         ],
@@ -749,7 +749,7 @@ describe("client", () => {
                     pfm_enabled: true,
                     dest_denom: "uatom",
                     supports_memo: true,
-                    rapid_relay: true,
+                    smart_relay: true,
                   },
                 },
               ],
@@ -777,7 +777,7 @@ describe("client", () => {
         destAssetChainID: "cosmoshub-4",
         destAssetDenom: "uatom",
         amountIn: "1000000",
-        rapidRelay: false,
+        smartRelay: false,
       });
 
       expect(response).toEqual({
@@ -815,7 +815,7 @@ describe("client", () => {
               pfmEnabled: true,
               destDenom: "uatom",
               supportsMemo: true,
-              rapidRelay: true,
+              smartRelay: true,
             },
           },
         ],

--- a/packages/core/src/types/__test__/converters.test.ts
+++ b/packages/core/src/types/__test__/converters.test.ts
@@ -828,7 +828,7 @@ test("transferFromJSON", () => {
     denom_out: "uatom",
     from_chain_id: "osmosis-1",
     to_chain_id: "cosmoshub-4",
-    rapid_relay: true,
+    smart_relay: true,
   };
 
   expect(transferFromJSON(transferJSON)).toEqual({
@@ -843,7 +843,7 @@ test("transferFromJSON", () => {
     denomOut: "uatom",
     fromChainID: "osmosis-1",
     toChainID: "cosmoshub-4",
-    rapidRelay: true,
+    smartRelay: true,
   });
 });
 
@@ -860,7 +860,7 @@ test("transferToJSON", () => {
     denomOut: "uatom",
     fromChainID: "osmosis-1",
     toChainID: "cosmoshub-4",
-    rapidRelay: false,
+    smartRelay: false,
   };
 
   expect(transferToJSON(transfer)).toEqual({
@@ -875,7 +875,7 @@ test("transferToJSON", () => {
     denom_out: "uatom",
     from_chain_id: "osmosis-1",
     to_chain_id: "cosmoshub-4",
-    rapid_relay: false,
+    smart_relay: false,
   });
 });
 
@@ -1257,7 +1257,7 @@ test("operationFromJSON - transfer", () => {
       to_chain_id: "cosmoshub-4",
       denom_in: "uosmo",
       denom_out: "uatom",
-      rapid_relay: false,
+      smart_relay: false,
     },
   };
 
@@ -1274,7 +1274,7 @@ test("operationFromJSON - transfer", () => {
       toChainID: "cosmoshub-4",
       denomIn: "uosmo",
       denomOut: "uatom",
-      rapidRelay: false,
+      smartRelay: false,
     },
   });
 });
@@ -1345,7 +1345,7 @@ test("operationToJSON - transfer", () => {
       toChainID: "cosmoshub-4",
       denomIn: "uosmo",
       denomOut: "uatom",
-      rapidRelay: false,
+      smartRelay: false,
     },
   };
 
@@ -1362,7 +1362,7 @@ test("operationToJSON - transfer", () => {
       to_chain_id: "cosmoshub-4",
       denom_in: "uosmo",
       denom_out: "uatom",
-      rapid_relay: false,
+      smart_relay: false,
     },
   });
 });
@@ -1460,7 +1460,7 @@ test("routeResponseFromJSON", () => {
           pfm_enabled: true,
           dest_denom: "uatom",
           supports_memo: true,
-          rapid_relay: false,
+          smart_relay: false,
           bridge_id: "IBC",
           denom_in: "uosmo",
           denom_out: "uatom",
@@ -1522,7 +1522,7 @@ test("routeResponseFromJSON", () => {
           pfmEnabled: true,
           destDenom: "uatom",
           supportsMemo: true,
-          rapidRelay: false,
+          smartRelay: false,
           bridgeID: "IBC",
           denomIn: "uosmo",
           denomOut: "uatom",
@@ -1586,7 +1586,7 @@ test("routeResponseToJSON", () => {
           pfmEnabled: true,
           destDenom: "uatom",
           supportsMemo: true,
-          rapidRelay: false,
+          smartRelay: false,
           bridgeID: "IBC",
           denomIn: "uosmo",
           denomOut: "uatom",
@@ -1648,7 +1648,7 @@ test("routeResponseToJSON", () => {
           pfm_enabled: true,
           dest_denom: "uatom",
           supports_memo: true,
-          rapid_relay: false,
+          smart_relay: false,
           bridge_id: "IBC",
           denom_in: "uosmo",
           denom_out: "uatom",
@@ -1804,7 +1804,7 @@ test("msgsRequestFromJSON", () => {
           pfm_enabled: true,
           dest_denom: "uatom",
           supports_memo: true,
-          rapid_relay: false,
+          smart_relay: false,
           bridge_id: "IBC",
           denom_in: "uosmo",
           denom_out: "uatom",
@@ -1874,7 +1874,7 @@ test("msgsRequestFromJSON", () => {
           pfmEnabled: true,
           destDenom: "uatom",
           supportsMemo: true,
-          rapidRelay: false,
+          smartRelay: false,
           bridgeID: "IBC",
           denomIn: "uosmo",
           denomOut: "uatom",
@@ -1946,7 +1946,7 @@ test("msgsRequestToJSON", () => {
           pfmEnabled: true,
           destDenom: "uatom",
           supportsMemo: true,
-          rapidRelay: false,
+          smartRelay: false,
           bridgeID: "IBC",
           denomIn: "uosmo",
           denomOut: "uatom",
@@ -2016,7 +2016,7 @@ test("msgsRequestToJSON", () => {
           pfm_enabled: true,
           dest_denom: "uatom",
           supports_memo: true,
-          rapid_relay: false,
+          smart_relay: false,
           bridge_id: "IBC",
           denom_in: "uosmo",
           denom_out: "uatom",

--- a/packages/core/src/types/converters.ts
+++ b/packages/core/src/types/converters.ts
@@ -467,7 +467,7 @@ export function routeRequestFromJSON(
       experimentalFeatures: routeRequestJSON.experimental_features,
       bridges: routeRequestJSON.bridges,
       allowMultiTx: routeRequestJSON.allow_multi_tx,
-      rapidRelay: routeRequestJSON.rapid_relay,
+      smartRelay: routeRequestJSON.smart_relay,
     };
   }
 
@@ -487,7 +487,7 @@ export function routeRequestFromJSON(
     experimentalFeatures: routeRequestJSON.experimental_features,
     bridges: routeRequestJSON.bridges,
     allowMultiTx: routeRequestJSON.allow_multi_tx,
-    rapidRelay: routeRequestJSON.rapid_relay,
+    smartRelay: routeRequestJSON.smart_relay,
   };
 }
 
@@ -511,7 +511,7 @@ export function routeRequestToJSON(
       experimental_features: routeRequest.experimentalFeatures,
       bridges: routeRequest.bridges,
       allow_multi_tx: routeRequest.allowMultiTx,
-      rapid_relay: routeRequest.rapidRelay,
+      smart_relay: routeRequest.smartRelay,
     };
   }
 
@@ -531,7 +531,7 @@ export function routeRequestToJSON(
     experimental_features: routeRequest.experimentalFeatures,
     bridges: routeRequest.bridges,
     allow_multi_tx: routeRequest.allowMultiTx,
-    rapid_relay: routeRequest.rapidRelay,
+    smart_relay: routeRequest.smartRelay,
   };
 }
 
@@ -555,7 +555,7 @@ export function transferFromJSON(transferJSON: TransferJSON): Transfer {
 
     destDenom: transferJSON.dest_denom,
     chainID: transferJSON.chain_id,
-    rapidRelay: transferJSON.rapid_relay,
+    smartRelay: transferJSON.smart_relay,
   };
 }
 
@@ -579,7 +579,7 @@ export function transferToJSON(transfer: Transfer): TransferJSON {
 
     dest_denom: transfer.destDenom,
     chain_id: transfer.chainID,
-    rapid_relay: transfer.rapidRelay,
+    smart_relay: transfer.smartRelay,
   };
 }
 
@@ -1222,7 +1222,7 @@ export function axelarTransferFromJSON(
       : undefined,
 
     bridgeID: axelarTransferJSON.bridge_id,
-    rapidRelay: axelarTransferJSON.rapid_relay,
+    smartRelay: axelarTransferJSON.smart_relay,
   };
 }
 
@@ -1251,7 +1251,7 @@ export function axelarTransferToJSON(
       : undefined,
 
     bridge_id: axelarTransfer.bridgeID,
-    rapid_relay: axelarTransfer.rapidRelay,
+    smart_relay: axelarTransfer.smartRelay,
   };
 }
 
@@ -1277,7 +1277,7 @@ export function cctpTransferFromJSON(value: CCTPTransferJSON): CCTPTransfer {
     bridgeID: value.bridge_id,
     denomIn: value.denom_in,
     denomOut: value.denom_out,
-    rapidRelay: value.rapid_relay,
+    smartRelay: value.smart_relay,
   };
 }
 
@@ -1289,7 +1289,7 @@ export function cctpTransferToJSON(value: CCTPTransfer): CCTPTransferJSON {
     bridge_id: value.bridgeID,
     denom_in: value.denomIn,
     denom_out: value.denomOut,
-    rapid_relay: value.rapidRelay,
+    smart_relay: value.smartRelay,
   };
 }
 
@@ -1306,7 +1306,7 @@ export function hyperlaneTransferFromJSON(
     usdFeeAmount: value.usd_fee_amount,
     feeAsset: assetFromJSON(value.fee_asset),
     bridgeID: value.bridge_id,
-    rapidRelay: value.rapid_relay,
+    smartRelay: value.smart_relay,
   };
 }
 
@@ -1323,7 +1323,7 @@ export function hyperlaneTransferToJSON(
     usd_fee_amount: value.usdFeeAmount,
     fee_asset: assetToJSON(value.feeAsset),
     bridge_id: value.bridgeID,
-    rapid_relay: value.rapidRelay,
+    smart_relay: value.smartRelay,
   };
 }
 
@@ -2006,7 +2006,7 @@ export function msgsDirectRequestFromJSON(
     swapVenue:
       msgDirectRequestJSON.swap_venue &&
       swapVenueFromJSON(msgDirectRequestJSON.swap_venue),
-    rapidRelay: msgDirectRequestJSON.rapid_relay,
+      smartRelay: msgDirectRequestJSON.smart_relay,
   };
 }
 
@@ -2034,6 +2034,6 @@ export function msgsDirectRequestToJSON(
     post_route_handler:
       msgDirectRequest.postRouteHandler &&
       postHandlerToJSON(msgDirectRequest.postRouteHandler),
-    rapid_relay: msgDirectRequest.rapidRelay,
+      smart_relay: msgDirectRequest.smartRelay,
   };
 }

--- a/packages/core/src/types/shared.ts
+++ b/packages/core/src/types/shared.ts
@@ -68,7 +68,7 @@ export type TransferJSON = {
   fee_asset?: AssetJSON;
 
   bridge_id: BridgeType;
-  rapid_relay: boolean;
+  smart_relay: boolean;
 
   /**
    * @deprecated use `from_chain_id` and `to_chain_id` instead
@@ -97,7 +97,7 @@ export type Transfer = {
   feeAsset?: Asset;
 
   bridgeID: BridgeType;
-  rapidRelay: boolean;
+  smartRelay: boolean;
 
   /**
    * @deprecated use `fromChainID` and `toChainID` instead
@@ -130,7 +130,7 @@ export type AxelarTransferJSON = {
   ibc_transfer_to_axelar?: TransferJSON;
 
   bridge_id: BridgeType;
-  rapid_relay: boolean;
+  smart_relay: boolean;
 };
 
 export type AxelarTransfer = {
@@ -153,7 +153,7 @@ export type AxelarTransfer = {
   ibcTransferToAxelar?: Transfer;
 
   bridgeID: BridgeType;
-  rapidRelay: boolean;
+  smartRelay: boolean;
 };
 
 export type BankSendJSON = {
@@ -208,7 +208,7 @@ export type CCTPTransferJSON = {
   bridge_id: BridgeType;
   denom_in: string;
   denom_out: string;
-  rapid_relay: boolean;
+  smart_relay: boolean;
 };
 
 export type CCTPTransfer = {
@@ -218,7 +218,7 @@ export type CCTPTransfer = {
   bridgeID: BridgeType;
   denomIn: string;
   denomOut: string;
-  rapidRelay: boolean;
+  smartRelay: boolean;
 };
 
 export type HyperlaneTransferJSON = {
@@ -231,7 +231,7 @@ export type HyperlaneTransferJSON = {
   usd_fee_amount?: string;
   fee_asset: AssetJSON;
   bridge_id: BridgeType;
-  rapid_relay: boolean;
+  smart_relay: boolean;
 };
 
 export type HyperlaneTransfer = {
@@ -244,7 +244,7 @@ export type HyperlaneTransfer = {
   usdFeeAmount?: string;
   feeAsset: Asset;
   bridgeID: BridgeType;
-  rapidRelay: boolean;
+  smartRelay: boolean;
 };
 
 export type SwapVenueJSON = {

--- a/packages/core/src/types/unified.ts
+++ b/packages/core/src/types/unified.ts
@@ -136,7 +136,7 @@ export type RouteRequestBaseJSON = {
   experimental_features?: ExperimentalFeature[];
   bridges?: BridgeType[];
   allow_multi_tx?: boolean;
-  rapid_relay?: boolean;
+  smart_relay?: boolean;
 };
 
 export type RouteRequestGivenInJSON = RouteRequestBaseJSON & {
@@ -178,7 +178,7 @@ export type RouteRequestBase = {
   experimentalFeatures?: ExperimentalFeature[];
   bridges?: BridgeType[];
   allowMultiTx?: boolean;
-  rapidRelay?: boolean;
+  smartRelay?: boolean;
 };
 
 export type RouteRequestGivenIn = RouteRequestBase & {
@@ -353,7 +353,7 @@ export type MsgsDirectRequestJSON = {
   experimental_features?: ExperimentalFeature[];
   bridges?: BridgeType[];
   allow_multi_tx?: boolean;
-  rapid_relay?: boolean;
+  smart_relay?: boolean;
 };
 
 export type MsgsDirectRequest = {
@@ -378,7 +378,7 @@ export type MsgsDirectRequest = {
   experimentalFeatures?: ExperimentalFeature[];
   bridges?: BridgeType[];
   allowMultiTx?: boolean;
-  rapidRelay?: boolean;
+  smartRelay?: boolean;
 };
 
 export type MsgJSON =

--- a/packages/core/src/types/unified.ts
+++ b/packages/core/src/types/unified.ts
@@ -202,7 +202,7 @@ export type RouteWarning = {
   message: string;
 };
 
-export type FeeType = "RAPID_RELAY";
+export type FeeType = "SMART_RELAY";
 
 export type EstimatedFee = {
   feeType: FeeType;


### PR DESCRIPTION
- Adding a breaking change to Skip API to rename `rapid_relay` to `smart_relay`, this PR makes the required naming changes for the router sdk