### PR TITLE
Fix/add Types, add ibcCapabilitiesFromJSON ibcCapabilitiesToJSON

### DIFF
--- a/packages/core/src/__test__/client.test.ts
+++ b/packages/core/src/__test__/client.test.ts
@@ -60,6 +60,12 @@ describe("client", () => {
                   logo_uri:
                     "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
                   bech32_prefix: "osmo",
+                  ibc_capabilities: {
+                    cosmos_pfm: true,
+                    cosmos_ibc_hooks: true,
+                    cosmos_memo: true,
+                    cosmos_autopilot: false,
+                  },
                   fee_assets: [
                     {
                       denom: "uosmo",
@@ -117,6 +123,12 @@ describe("client", () => {
           logoURI:
             "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
           bech32Prefix: "osmo",
+          ibcCapabilities: {
+            cosmosPfm: true,
+            cosmosIbcHooks: true,
+            cosmosMemo: true,
+            cosmosAutopilot: false,
+          },
           feeAssets: [
             {
               denom: "uosmo",

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -1427,7 +1427,7 @@ export class SkipRouter {
   async getRecommendedGasPrice(chainID: string) {
     const feeInfo = await this.getFeeInfoForChain(chainID);
 
-    if (!feeInfo) {
+    if (!feeInfo || !feeInfo.gasPrice) {
       return undefined;
     }
 

--- a/packages/core/src/types/__test__/converters.test.ts
+++ b/packages/core/src/types/__test__/converters.test.ts
@@ -23,6 +23,8 @@ import {
   feeAssetToJSON,
   ibcAddressFromJSON,
   ibcAddressToJSON,
+  ibcCapabilitiesFromJSON,
+  ibcCapabilitiesToJSON,
   msgsRequestFromJSON,
   msgsRequestToJSON,
   multiChainMsgFromJSON,
@@ -94,7 +96,7 @@ import {
   TxStatusResponse,
   TxStatusResponseJSON,
 } from "../lifecycle";
-import { ChainJSON, FeeAssetJSON } from "../routing";
+import { ChainJSON, FeeAssetJSON, IbcCapabilitiesJSON } from "../routing";
 import {
   AffiliateJSON,
   Asset,
@@ -428,6 +430,12 @@ test("chainFromJSON", () => {
     logo_uri:
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
     bech32_prefix: "osmo",
+    ibc_capabilities: {
+      cosmos_pfm: false,
+      cosmos_ibc_hooks: false,
+      cosmos_memo: false,
+      cosmos_autopilot: false,
+    },
     fee_assets: [
       {
         denom: "uosmo",
@@ -472,6 +480,12 @@ test("chainFromJSON", () => {
     logoURI:
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
     bech32Prefix: "osmo",
+    ibcCapabilities: {
+      cosmos_pfm: false,
+      cosmos_ibc_hooks: false,
+      cosmos_memo: false,
+      cosmos_autopilot: false,
+    },
     feeAssets: [
       {
         denom: "uosmo",
@@ -518,6 +532,12 @@ test("chainToJSON", () => {
     logoURI:
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
     bech32Prefix: "osmo",
+    ibcCapabilities: {
+      cosmosPfm: false,
+      cosmosIbcHooks: false,
+      cosmosMemo: false,
+      cosmosAutopilot: false,
+    },
     feeAssets: [
       {
         denom: "uosmo",
@@ -562,6 +582,12 @@ test("chainToJSON", () => {
     logo_uri:
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
     bech32_prefix: "osmo",
+    ibc_capabilities: {
+      cosmos_pfm: false,
+      cosmos_ibc_hooks: false,
+      cosmos_memo: false,
+      cosmos_autopilot: false,
+    },
     fee_assets: [
       {
         denom: "uosmo",
@@ -612,6 +638,38 @@ test("feeAssetToJSON", () => {
       average: "0.025",
       high: "0.04",
     },
+  });
+});
+
+test("ibcCapabilitiesFromJSON", () => {
+  const ibcCapabilitiesJSON: IbcCapabilitiesJSON = {
+    cosmos_pfm: false,
+    cosmos_ibc_hooks: false,
+    cosmos_memo: false,
+    cosmos_autopilot: false,
+  };
+
+  expect(ibcCapabilitiesFromJSON(ibcCapabilitiesJSON)).toEqual({
+    cosmosPfm: false,
+    cosmosIbcHooks: false,
+    cosmosMemo: false,
+    cosmosAutopilot: false,
+  });
+});
+
+test("ibcCapabilitiesToJSON", () => {
+  const ibcCapabilities = {
+    cosmosPfm: false,
+    cosmosIbcHooks: false,
+    cosmosMemo: false,
+    cosmosAutopilot: false,
+  };
+
+  expect(ibcCapabilitiesToJSON(ibcCapabilities)).toEqual({
+    cosmos_pfm: false,
+    cosmos_ibc_hooks: false,
+    cosmos_memo: false,
+    cosmos_autopilot: false,
   });
 });
 

--- a/packages/core/src/types/__test__/converters.test.ts
+++ b/packages/core/src/types/__test__/converters.test.ts
@@ -96,7 +96,13 @@ import {
   TxStatusResponse,
   TxStatusResponseJSON,
 } from "../lifecycle";
-import { ChainJSON, FeeAssetJSON, IbcCapabilitiesJSON } from "../routing";
+import {
+  Chain,
+  ChainJSON,
+  FeeAssetJSON,
+  IbcCapabilities,
+  IbcCapabilitiesJSON,
+} from "../routing";
 import {
   AffiliateJSON,
   Asset,
@@ -481,10 +487,10 @@ test("chainFromJSON", () => {
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
     bech32Prefix: "osmo",
     ibcCapabilities: {
-      cosmos_pfm: true,
-      cosmos_ibc_hooks: true,
-      cosmos_memo: true,
-      cosmos_autopilot: false,
+      cosmosPfm: true,
+      cosmosIbcHooks: true,
+      cosmosMemo: true,
+      cosmosAutopilot: false,
     },
     feeAssets: [
       {
@@ -496,11 +502,11 @@ test("chainFromJSON", () => {
         },
       },
     ],
-  });
+  } as Chain);
 });
 
 test("chainToJSON", () => {
-  const chain = {
+  const chain: Chain = {
     chainName: "osmosis",
     chainID: "osmosis-1",
     pfmEnabled: true,
@@ -598,7 +604,7 @@ test("chainToJSON", () => {
         },
       },
     ],
-  });
+  } as ChainJSON);
 });
 
 test("feeAssetFromJSON", () => {
@@ -654,11 +660,11 @@ test("ibcCapabilitiesFromJSON", () => {
     cosmosIbcHooks: true,
     cosmosMemo: true,
     cosmosAutopilot: false,
-  });
+  } as IbcCapabilities);
 });
 
 test("ibcCapabilitiesToJSON", () => {
-  const ibcCapabilities = {
+  const ibcCapabilities: IbcCapabilities = {
     cosmosPfm: true,
     cosmosIbcHooks: true,
     cosmosMemo: true,
@@ -670,7 +676,7 @@ test("ibcCapabilitiesToJSON", () => {
     cosmos_ibc_hooks: true,
     cosmos_memo: true,
     cosmos_autopilot: false,
-  });
+  } as IbcCapabilitiesJSON);
 });
 
 test("recommendAssetsRequestFromJSON", () => {

--- a/packages/core/src/types/__test__/converters.test.ts
+++ b/packages/core/src/types/__test__/converters.test.ts
@@ -431,9 +431,9 @@ test("chainFromJSON", () => {
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
     bech32_prefix: "osmo",
     ibc_capabilities: {
-      cosmos_pfm: false,
-      cosmos_ibc_hooks: false,
-      cosmos_memo: false,
+      cosmos_pfm: true,
+      cosmos_ibc_hooks: true,
+      cosmos_memo: true,
       cosmos_autopilot: false,
     },
     fee_assets: [
@@ -481,9 +481,9 @@ test("chainFromJSON", () => {
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
     bech32Prefix: "osmo",
     ibcCapabilities: {
-      cosmos_pfm: false,
-      cosmos_ibc_hooks: false,
-      cosmos_memo: false,
+      cosmos_pfm: true,
+      cosmos_ibc_hooks: true,
+      cosmos_memo: true,
       cosmos_autopilot: false,
     },
     feeAssets: [
@@ -533,9 +533,9 @@ test("chainToJSON", () => {
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
     bech32Prefix: "osmo",
     ibcCapabilities: {
-      cosmosPfm: false,
-      cosmosIbcHooks: false,
-      cosmosMemo: false,
+      cosmosPfm: true,
+      cosmosIbcHooks: true,
+      cosmosMemo: true,
       cosmosAutopilot: false,
     },
     feeAssets: [
@@ -583,9 +583,9 @@ test("chainToJSON", () => {
       "https://raw.githubusercontent.com/cosmos/chain-registry/master/osmosis/images/osmosis-chain-logo.png",
     bech32_prefix: "osmo",
     ibc_capabilities: {
-      cosmos_pfm: false,
-      cosmos_ibc_hooks: false,
-      cosmos_memo: false,
+      cosmos_pfm: true,
+      cosmos_ibc_hooks: true,
+      cosmos_memo: true,
       cosmos_autopilot: false,
     },
     fee_assets: [
@@ -643,32 +643,32 @@ test("feeAssetToJSON", () => {
 
 test("ibcCapabilitiesFromJSON", () => {
   const ibcCapabilitiesJSON: IbcCapabilitiesJSON = {
-    cosmos_pfm: false,
-    cosmos_ibc_hooks: false,
-    cosmos_memo: false,
+    cosmos_pfm: true,
+    cosmos_ibc_hooks: true,
+    cosmos_memo: true,
     cosmos_autopilot: false,
   };
 
   expect(ibcCapabilitiesFromJSON(ibcCapabilitiesJSON)).toEqual({
-    cosmosPfm: false,
-    cosmosIbcHooks: false,
-    cosmosMemo: false,
+    cosmosPfm: true,
+    cosmosIbcHooks: true,
+    cosmosMemo: true,
     cosmosAutopilot: false,
   });
 });
 
 test("ibcCapabilitiesToJSON", () => {
   const ibcCapabilities = {
-    cosmosPfm: false,
-    cosmosIbcHooks: false,
-    cosmosMemo: false,
+    cosmosPfm: true,
+    cosmosIbcHooks: true,
+    cosmosMemo: true,
     cosmosAutopilot: false,
   };
 
   expect(ibcCapabilitiesToJSON(ibcCapabilities)).toEqual({
-    cosmos_pfm: false,
-    cosmos_ibc_hooks: false,
-    cosmos_memo: false,
+    cosmos_pfm: true,
+    cosmos_ibc_hooks: true,
+    cosmos_memo: true,
     cosmos_autopilot: false,
   });
 });

--- a/packages/core/src/types/converters.ts
+++ b/packages/core/src/types/converters.ts
@@ -42,7 +42,14 @@ import {
   TxStatusResponse,
   TxStatusResponseJSON,
 } from "./lifecycle";
-import { Chain, ChainJSON, FeeAsset, FeeAssetJSON } from "./routing";
+import {
+  Chain,
+  ChainJSON,
+  FeeAsset,
+  FeeAssetJSON,
+  IbcCapabilities,
+  IbcCapabilitiesJSON,
+} from "./routing";
 import {
   Affiliate,
   AffiliateJSON,
@@ -283,6 +290,7 @@ export function chainFromJSON(chainJSON: ChainJSON): Chain {
     bech32Prefix: chainJSON.bech32_prefix,
     feeAssets: chainJSON.fee_assets.map(feeAssetFromJSON),
     chainType: chainJSON.chain_type,
+    ibcCapabilities: ibcCapabilitiesFromJSON(chainJSON.ibc_capabilities),
     isTestnet: chainJSON.is_testnet,
   };
 }
@@ -300,6 +308,7 @@ export function chainToJSON(chain: Chain): ChainJSON {
     bech32_prefix: chain.bech32Prefix,
     fee_assets: chain.feeAssets.map(feeAssetToJSON),
     chain_type: chain.chainType,
+    ibc_capabilities: ibcCapabilitiesToJSON(chain.ibcCapabilities),
     is_testnet: chain.isTestnet,
   };
 }
@@ -315,6 +324,28 @@ export function feeAssetToJSON(feeAsset: FeeAsset): FeeAssetJSON {
   return {
     denom: feeAsset.denom,
     gas_price: feeAsset.gasPrice,
+  };
+}
+
+export function ibcCapabilitiesFromJSON(
+  ibcCapabilitiesJSON: IbcCapabilitiesJSON,
+): IbcCapabilities {
+  return {
+    cosmosPfm: ibcCapabilitiesJSON.cosmos_pfm,
+    cosmosIbcHooks: ibcCapabilitiesJSON.cosmos_ibc_hooks,
+    cosmosMemo: ibcCapabilitiesJSON.cosmos_memo,
+    cosmosAutopilot: ibcCapabilitiesJSON.cosmos_autopilot,
+  };
+}
+
+export function ibcCapabilitiesToJSON(
+  ibcCapabilities: IbcCapabilities,
+): IbcCapabilitiesJSON {
+  return {
+    cosmos_pfm: ibcCapabilities.cosmosPfm,
+    cosmos_ibc_hooks: ibcCapabilities.cosmosIbcHooks,
+    cosmos_memo: ibcCapabilities.cosmosMemo,
+    cosmos_autopilot: ibcCapabilities.cosmosAutopilot,
   };
 }
 
@@ -450,9 +481,8 @@ export function swapVenueRequestToJSON(
 export function routeRequestFromJSON(
   routeRequestJSON: RouteRequestJSON,
 ): RouteRequest {
-
-  const swapVenues = routeRequestJSON.swap_venues ?
-    routeRequestJSON.swap_venues.map(swapVenueRequestFromJSON)
+  const swapVenues = routeRequestJSON.swap_venues
+    ? routeRequestJSON.swap_venues.map(swapVenueRequestFromJSON)
     : undefined;
 
   if (routeRequestJSON.amount_in !== undefined) {
@@ -501,8 +531,8 @@ export function routeRequestFromJSON(
 export function routeRequestToJSON(
   routeRequest: RouteRequest,
 ): RouteRequestJSON {
-  const swapVenues = routeRequest.swapVenues ?
-    routeRequest.swapVenues.map(swapVenueRequestToJSON)
+  const swapVenues = routeRequest.swapVenues
+    ? routeRequest.swapVenues.map(swapVenueRequestToJSON)
     : undefined;
 
   if (routeRequest.amountIn !== undefined) {
@@ -536,8 +566,8 @@ export function routeRequestToJSON(
 
     cumulative_affiliate_fee_bps: routeRequest.cumulativeAffiliateFeeBPS,
     swap_venue: routeRequest.swapVenue
-        ? swapVenueRequestToJSON(routeRequest.swapVenue)
-        : undefined,
+      ? swapVenueRequestToJSON(routeRequest.swapVenue)
+      : undefined,
     swap_venues: swapVenues,
     allow_unsafe: routeRequest.allowUnsafe,
     client_id: routeRequest.clientID,
@@ -724,7 +754,7 @@ export function operationFromJSON(operationJSON: OperationJSON): Operation {
       txIndex: operationJSON.tx_index,
       amountIn: operationJSON.amount_in,
       amountOut: operationJSON.amount_out,
-     };
+    };
   }
 
   if ("axelar_transfer" in operationJSON) {
@@ -742,7 +772,7 @@ export function operationFromJSON(operationJSON: OperationJSON): Operation {
       txIndex: operationJSON.tx_index,
       amountIn: operationJSON.amount_in,
       amountOut: operationJSON.amount_out,
-     };
+    };
   }
 
   if ("hyperlane_transfer" in operationJSON) {
@@ -761,7 +791,7 @@ export function operationFromJSON(operationJSON: OperationJSON): Operation {
     txIndex: operationJSON.tx_index,
     amountIn: operationJSON.amount_in,
     amountOut: operationJSON.amount_out,
-   };
+  };
 }
 
 export function operationToJSON(operation: Operation): OperationJSON {
@@ -771,7 +801,7 @@ export function operationToJSON(operation: Operation): OperationJSON {
       tx_index: operation.txIndex,
       amount_in: operation.amountIn,
       amount_out: operation.amountOut,
-     };
+    };
   }
 
   if ("bankSend" in operation) {
@@ -780,7 +810,7 @@ export function operationToJSON(operation: Operation): OperationJSON {
       tx_index: operation.txIndex,
       amount_in: operation.amountIn,
       amount_out: operation.amountOut,
-     };
+    };
   }
 
   if ("axelarTransfer" in operation) {
@@ -798,7 +828,7 @@ export function operationToJSON(operation: Operation): OperationJSON {
       tx_index: operation.txIndex,
       amount_in: operation.amountIn,
       amount_out: operation.amountOut,
-     };
+    };
   }
 
   if ("hyperlaneTransfer" in operation) {
@@ -815,7 +845,7 @@ export function operationToJSON(operation: Operation): OperationJSON {
     tx_index: operation.txIndex,
     amount_in: operation.amountIn,
     amount_out: operation.amountOut,
-   };
+  };
 }
 
 export function routeResponseFromJSON(
@@ -846,7 +876,7 @@ export function routeResponseFromJSON(
 
     warning: routeResponseJSON.warning,
     estimatedFees: routeResponseJSON.estimated_fees?.length
-      ? routeResponseJSON.estimated_fees.map((i) => estimatedFeeFromJSON(i))
+      ? routeResponseJSON.estimated_fees.map(i => estimatedFeeFromJSON(i))
       : [],
   };
 }
@@ -878,9 +908,7 @@ export function routeResponseToJSON(
     swap_price_impact_percent: routeResponse.swapPriceImpactPercent,
 
     warning: routeResponse.warning,
-    estimated_fees: routeResponse.estimatedFees.map((i) =>
-      estimatedFeeToJSON(i),
-    ),
+    estimated_fees: routeResponse.estimatedFees.map(i => estimatedFeeToJSON(i)),
     // estimated_fees: routeResponse.estimatedFees?.length
     //   ? routeResponse.estimatedFees.map((i) => estimatedFeeToJSON(i))
     //   : [],
@@ -1450,8 +1478,9 @@ export function evmTxToJSON(evmTx: EvmTx): EvmTxJSON {
     to: evmTx.to,
     value: evmTx.value,
     data: evmTx.data,
-    required_erc20_approvals:
-      evmTx.requiredERC20Approvals.map(erc20ApprovalToJSON),
+    required_erc20_approvals: evmTx.requiredERC20Approvals.map(
+      erc20ApprovalToJSON,
+    ),
   };
 }
 
@@ -1549,11 +1578,11 @@ export function messageResponseFromJSON(
   response: MsgsResponseJSON,
 ): MsgsResponse {
   return {
-    estimatedFees: response.estimated_fees?.map((fee) =>
+    estimatedFees: response.estimated_fees?.map(fee =>
       estimatedFeeFromJSON(fee),
     ),
-    msgs: response.msgs.map((msg) => msgFromJSON(msg)),
-    txs: response.txs?.map((tx) => txFromJSON(tx)),
+    msgs: response.msgs.map(msg => msgFromJSON(msg)),
+    txs: response.txs?.map(tx => txFromJSON(tx)),
   };
 }
 
@@ -2112,10 +2141,11 @@ export function msgsDirectRequestToJSON(
     swap_venue:
       msgDirectRequest.swapVenue && swapVenueToJSON(msgDirectRequest.swapVenue),
     swap_venues:
-      msgDirectRequest.swapVenues && msgDirectRequest.swapVenues.map(swapVenueToJSON),
+      msgDirectRequest.swapVenues &&
+      msgDirectRequest.swapVenues.map(swapVenueToJSON),
     post_route_handler:
       msgDirectRequest.postRouteHandler &&
       postHandlerToJSON(msgDirectRequest.postRouteHandler),
-      smart_relay: msgDirectRequest.smartRelay,
+    smart_relay: msgDirectRequest.smartRelay,
   };
 }

--- a/packages/core/src/types/routing.ts
+++ b/packages/core/src/types/routing.ts
@@ -19,6 +19,20 @@ export type FeeAssetJSON = {
   gas_price: GasPriceInfo | null;
 };
 
+export type IbcCapabilities = {
+  cosmosPfm: boolean;
+  cosmosIbcHooks: boolean;
+  cosmosMemo: boolean;
+  cosmosAutopilot: boolean;
+};
+
+export type IbcCapabilitiesJSON = {
+  cosmos_pfm: boolean;
+  cosmos_ibc_hooks: boolean;
+  cosmos_memo: boolean;
+  cosmos_autopilot: boolean;
+};
+
 export type Chain = {
   chainName: string;
   chainID: string;
@@ -31,12 +45,7 @@ export type Chain = {
   bech32Prefix: string;
   feeAssets: FeeAsset[];
   chainType: string;
-  ibcCapabilities: {
-    cosmosPfm: boolean;
-    cosmosIbcHooks: boolean;
-    cosmosMemo: boolean;
-    cosmosAutopilot: boolean;
-  };
+  ibcCapabilities: IbcCapabilities;
   isTestnet: boolean;
 };
 
@@ -52,12 +61,7 @@ export type ChainJSON = {
   bech32_prefix: string;
   fee_assets: FeeAssetJSON[];
   chain_type: string;
-  ibc_capabilities: {
-    cosmos_pfm: boolean;
-    cosmos_ibc_hooks: boolean;
-    cosmos_memo: boolean;
-    cosmos_autopilot: boolean;
-  };
+  ibc_capabilities: IbcCapabilitiesJSON;
   is_testnet: boolean;
 };
 

--- a/packages/core/src/types/routing.ts
+++ b/packages/core/src/types/routing.ts
@@ -23,19 +23,19 @@ export type Chain = {
   chainName: string;
   chainID: string;
   pfmEnabled: boolean;
-  cosmosSDKVersion: string;
-  modules: Record<string, ModuleVersionInfo>;
+  cosmosSDKVersion?: string;
+  modules?: Record<string, ModuleVersionInfo>;
   cosmosModuleSupport: ModuleSupport;
   supportsMemo: boolean;
   logoURI?: string;
   bech32Prefix: string;
   feeAssets: FeeAsset[];
   chainType: string;
-  ibc_capabilities: {
-    cosmos_pfm: boolean;
-    cosmos_ibc_hooks: boolean;
-    cosmos_memo: boolean;
-    cosmos_autopilot: boolean;
+  ibcCapabilities: {
+    cosmosPfm: boolean;
+    cosmosIbcHooks: boolean;
+    cosmosMemo: boolean;
+    cosmosAutopilot: boolean;
   };
   isTestnet: boolean;
 };
@@ -44,8 +44,8 @@ export type ChainJSON = {
   chain_name: string;
   chain_id: string;
   pfm_enabled: boolean;
-  cosmos_sdk_version: string;
-  modules: Record<string, ModuleVersionInfo>;
+  cosmos_sdk_version?: string;
+  modules?: Record<string, ModuleVersionInfo>;
   cosmos_module_support: ModuleSupport;
   supports_memo: boolean;
   logo_uri?: string;

--- a/packages/core/src/types/routing.ts
+++ b/packages/core/src/types/routing.ts
@@ -11,12 +11,12 @@ export type GasPriceInfo = {
 
 export type FeeAsset = {
   denom: string;
-  gasPrice: GasPriceInfo;
+  gasPrice: GasPriceInfo | null;
 };
 
 export type FeeAssetJSON = {
   denom: string;
-  gas_price: GasPriceInfo;
+  gas_price: GasPriceInfo | null;
 };
 
 export type Chain = {
@@ -31,6 +31,12 @@ export type Chain = {
   bech32Prefix: string;
   feeAssets: FeeAsset[];
   chainType: string;
+  ibc_capabilities: {
+    cosmos_pfm: boolean;
+    cosmos_ibc_hooks: boolean;
+    cosmos_memo: boolean;
+    cosmos_autopilot: boolean;
+  };
   isTestnet: boolean;
 };
 
@@ -46,6 +52,12 @@ export type ChainJSON = {
   bech32_prefix: string;
   fee_assets: FeeAssetJSON[];
   chain_type: string;
+  ibc_capabilities: {
+    cosmos_pfm: boolean;
+    cosmos_ibc_hooks: boolean;
+    cosmos_memo: boolean;
+    cosmos_autopilot: boolean;
+  };
   is_testnet: boolean;
 };
 


### PR DESCRIPTION
- **Added**: Types for _ibcCapabilities_ (currently missing)
- **Added**: Corresponding ibcCapabilities-Functions (_ibcCapabilitiesFromJSON_, _ibcCapabilitiesToJSON_)
------------
- **Fixed**: Type _FeeAsset_ / _FeeAssetJSON_ => "gasPrice" can be null
<img width="713" alt="CleanShot 2024-05-08 at 07 14 07@2x" src="https://github.com/skip-mev/skip-router-sdk/assets/99530800/0f9f02b3-4cb9-4320-8b77-242c852959ea">

------------

- **Fixed**: cosmosSDKVersion => optional
- **Fixed**: modules => optional

Both are not included in the response at the moment:

<img width="652" alt="CleanShot 2024-05-08 at 07 18 45@2x" src="https://github.com/skip-mev/skip-router-sdk/assets/99530800/e85c55c9-389c-4c4e-9a9d-1d1d581bdcfe">



<br><br>

PS: sorry for the reformatting ;)