### PR TITLE
[API-2914] Add chain_ids_to_affiliates fields to MsgsRequest and MsgsDirectRequest

### DIFF
--- a/.changeset/real-steaks-smash.md
+++ b/.changeset/real-steaks-smash.md
@@ -1,0 +1,5 @@
+---
+"@skip-router/core": patch
+---
+
+Add chain_ids_to_affiliates field to MsgsRequest and MsgsDirectRequest

--- a/packages/core/src/types/converters.ts
+++ b/packages/core/src/types/converters.ts
@@ -109,6 +109,8 @@ import {
   TransferJSON,
   SmartSwapOptions,
   SmartSwapOptionsJSON,
+  ChainAffiliatesJSON,
+  ChainAffiliates,
 } from "./shared";
 import {
   AssetBetweenChains,
@@ -1045,7 +1047,9 @@ export function msgsRequestFromJSON(
     estimatedAmountOut: msgsRequestJSON.estimated_amount_out,
     slippageTolerancePercent: msgsRequestJSON.slippage_tolerance_percent,
     affiliates: msgsRequestJSON.affiliates?.map(affiliateFromJSON),
-
+    chainIDsToAffiliates: msgsRequestJSON.chain_ids_to_affiliates
+      ? chainIDsToAffiliatesMapFromJSON(msgsRequestJSON.chain_ids_to_affiliates)
+      : undefined,
     postRouteHandler:
       msgsRequestJSON.post_route_handler &&
       postHandlerFromJSON(msgsRequestJSON.post_route_handler),
@@ -1066,7 +1070,9 @@ export function msgsRequestToJSON(msgsRequest: MsgsRequest): MsgsRequestJSON {
     estimated_amount_out: msgsRequest.estimatedAmountOut,
     slippage_tolerance_percent: msgsRequest.slippageTolerancePercent,
     affiliates: msgsRequest.affiliates?.map(affiliateToJSON),
-
+    chain_ids_to_affiliates: msgsRequest.chainIDsToAffiliates
+      ? chainIDsToAffiliatesMapToJSON(msgsRequest.chainIDsToAffiliates)
+      : undefined,
     post_route_handler:
       msgsRequest.postRouteHandler &&
       postHandlerToJSON(msgsRequest.postRouteHandler),
@@ -2156,6 +2162,11 @@ export function msgsDirectRequestFromJSON(
     chainIdsToAddresses: msgDirectRequestJSON.chain_ids_to_addresses,
     slippageTolerancePercent: msgDirectRequestJSON.slippage_tolerance_percent,
     affiliates: msgDirectRequestJSON.affiliates?.map(affiliateFromJSON),
+    chainIDsToAffiliates: msgDirectRequestJSON.chain_ids_to_affiliates
+      ? chainIDsToAffiliatesMapFromJSON(
+          msgDirectRequestJSON.chain_ids_to_affiliates,
+        )
+      : undefined,
     timeoutSeconds: msgDirectRequestJSON.timeout_seconds,
     postRouteHandler:
       msgDirectRequestJSON.post_route_handler &&
@@ -2186,6 +2197,9 @@ export function msgsDirectRequestToJSON(
     chain_ids_to_addresses: msgDirectRequest.chainIdsToAddresses,
     slippage_tolerance_percent: msgDirectRequest.slippageTolerancePercent,
     affiliates: msgDirectRequest.affiliates?.map(affiliateToJSON),
+    chain_ids_to_affiliates: msgDirectRequest.chainIDsToAffiliates
+      ? chainIDsToAffiliatesMapToJSON(msgDirectRequest.chainIDsToAffiliates)
+      : undefined,
     allow_multi_tx: msgDirectRequest.allowMultiTx,
     allow_unsafe: msgDirectRequest.allowUnsafe,
     bridges: msgDirectRequest.bridges,
@@ -2219,5 +2233,41 @@ export function smartSwapOptionsToJSON(
 ): SmartSwapOptionsJSON {
   return {
     split_routes: smartSwapOptions.splitRoutes,
+  };
+}
+
+export function chainIDsToAffiliatesMapFromJSON(
+  value: Record<string, ChainAffiliatesJSON>,
+): Record<string, ChainAffiliates> {
+  const result: Record<string, ChainAffiliates> = {};
+  for (const key of Object.keys(value)) {
+    result[key] = chainAffiliatesFromJSON(value[key]!);
+  }
+  return result;
+}
+
+export function chainIDsToAffiliatesMapToJSON(
+  value: Record<string, ChainAffiliates>,
+): Record<string, ChainAffiliatesJSON> {
+  const result: Record<string, ChainAffiliatesJSON> = {};
+  for (const key of Object.keys(value)) {
+    result[key] = chainAffiliatesToJSON(value[key]!);
+  }
+  return result;
+}
+
+export function chainAffiliatesFromJSON(
+  value: ChainAffiliatesJSON,
+): ChainAffiliates {
+  return {
+    affiliates: value.affiliates.map(affiliateFromJSON),
+  };
+}
+
+export function chainAffiliatesToJSON(
+  value: ChainAffiliates,
+): ChainAffiliatesJSON {
+  return {
+    affiliates: value.affiliates.map(affiliateToJSON),
   };
 }

--- a/packages/core/src/types/shared.ts
+++ b/packages/core/src/types/shared.ts
@@ -371,6 +371,14 @@ export type Affiliate = {
   address: string;
 };
 
+export type ChainAffiliatesJSON = {
+  affiliates: AffiliateJSON[];
+};
+
+export type ChainAffiliates = {
+  affiliates: Affiliate[];
+};
+
 export type Reason = "UNKNOWN" | "BASE_TOKEN" | "MOST_LIQUID" | "DIRECT";
 
 export type CosmWasmContractMsgJSON = {

--- a/packages/core/src/types/unified.ts
+++ b/packages/core/src/types/unified.ts
@@ -33,6 +33,8 @@ import {
   SvmTx,
   SmartSwapOptions,
   SmartSwapOptionsJSON,
+  ChainAffiliatesJSON,
+  ChainAffiliates,
 } from "./shared";
 
 export type AssetsRequestJSON = {
@@ -345,7 +347,7 @@ export type MsgsRequestJSON = {
   estimated_amount_out?: string;
   slippage_tolerance_percent?: string;
   affiliates?: AffiliateJSON[];
-
+  chain_ids_to_affiliates?: Record<string, ChainAffiliatesJSON>;
   post_route_handler?: PostHandlerJSON;
 };
 
@@ -365,6 +367,7 @@ export type MsgsRequest = {
   estimatedAmountOut?: string;
   slippageTolerancePercent?: string;
   affiliates?: Affiliate[];
+  chainIDsToAffiliates?: Record<string, ChainAffiliates>;
 
   postRouteHandler?: PostHandler;
 };
@@ -385,6 +388,7 @@ export type MsgsDirectRequestJSON = {
   timeout_seconds?: string;
 
   affiliates?: AffiliateJSON[];
+  chain_ids_to_affiliates?: Record<string, ChainAffiliatesJSON>;
 
   post_route_handler?: PostHandlerJSON;
 
@@ -411,6 +415,7 @@ export type MsgsDirectRequest = {
   slippageTolerancePercent?: string;
   timeoutSeconds?: string;
   affiliates?: Affiliate[];
+  chainIDsToAffiliates?: Record<string, ChainAffiliates>;
 
   postRouteHandler?: PostHandler;
 


### PR DESCRIPTION
Adds `chain_ids_to_affiliates` field to MsgsRequest and MsgsDirectRequest types. Previously the API only allowed affiliates that were used in a route to be passed, for messages direct this is an issue because you don't always know what chain the swaps will happen on. Now we accept a map of chainIDs to arrays of affiliates to be passed and don't error if a chain isn't used in a route. See [API-2731](https://linear.app/skip/issue/API-2731/handle-addresses-for-non-swap-venue-chains-in-affiliate-fees) for more info.