### PR TITLE
check route.requiredChainAddresses instead of route.chainIDs

### DIFF
--- a/.changeset/light-clocks-hug.md
+++ b/.changeset/light-clocks-hug.md
@@ -1,0 +1,5 @@
+---
+"@skip-router/core": patch
+---
+
+Updates address validate logic to check route.requiredChainAddresses instead of route.chainIDs

--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -205,7 +205,7 @@ export class SkipRouter {
     const { route, userAddresses } = options;
 
     const addressList = userAddresses.map(({ chainID, address }, i) => {
-      if (route.chainIDs[i] !== chainID) {
+      if (route.requiredChainAddresses[i] !== chainID) {
         raise(`executeRoute error: invalid address for chain '${chainID}'`);
       }
 


### PR DESCRIPTION
Updates address validate logic to check `route.requiredChainAddresses` instead of `route.chainIDs`